### PR TITLE
Continuous GH Pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,4 +60,7 @@ jobs:
       - install_dependencies:
           image: "node"
           version: "1"
+      - run: |
+          git config user.email "ci-deployment@mavenlink"
+          git config user.name "CI Deployment"
       - run: yarn deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,21 @@ workflows:
               ignore:
                 - gh-pages
 
+commands:
+  install_dependencies:
+    description: "Install dependencies with smart caching"
+    steps:
+      - restore_cache:
+          keys:
+          - v2-dependencies-2-{{ checksum "package.json" }}
+          - v2-dependencies-2-
+      - run: yarn install --frozen-lockfile
+      - save_cache:
+          paths:
+            - ~/.cache
+            - node_modules
+          key: v2-dependencies-2-{{ checksum "package.json" }}
+
 jobs:
   build_and_test:
     docker:
@@ -20,18 +35,7 @@ jobs:
     steps:
       - checkout
 
-      - restore_cache:
-          keys:
-          - v2-dependencies-2-{{ checksum "package.json" }}
-          - v2-dependencies-2-
-
-      - run: yarn install --frozen-lockfile
-
-      - save_cache:
-          paths:
-            - ~/.cache
-            - node_modules
-          key: v2-dependencies-2-{{ checksum "package.json" }}
+      - install_dependencies
 
       - run: yarn lint
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,20 +29,13 @@ jobs:
   build_and_test:
     docker:
       - image: cypress/base:8
-
     working_directory: ~/repo
-
     steps:
       - checkout
-
       - install_dependencies
-
       - run: yarn lint
-
       - run: yarn test
-
       - run:
           command: yarn start
           background: true
-
       - run: yarn run wait-on http://localhost:6060 && yarn cypress run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,14 +24,14 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - yarn-<< parameters.image >>-<< parameters.version >>-{{ checksum "package.json" }}
+            - &yarn_key yarn-<< parameters.image >>-<< parameters.version >>-{{ checksum "package.json" }}
             - yarn-<< parameters.image >>-<< parameters.version >>
       - run: yarn install --frozen-lockfile
       - save_cache:
           paths:
             - ~/.cache
             - node_modules
-          key: yarn-<< parameters.image >>-<< parameters.version >>-{{ checksum "package.json" }}
+          key: *yarn_key
 
 jobs:
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,10 @@ workflows:
               ignore:
                 - gh-pages
       - deploy:
+          filters:
+            branches:
+              only:
+                - master
           requires:
             - build_and_test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,17 @@
 version: 2.1
 
-jobs:
-  build:
-    branches:
-      ignore:
-        - gh-pages
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - build_and_test:
+          filters:
+            branches:
+              ignore:
+                - gh-pages
 
+jobs:
+  build_and_test:
     docker:
       - image: cypress/base:8
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,4 +61,7 @@ jobs:
       - run: |
           git config user.email "ci-deployment@mavenlink"
           git config user.name "CI Deployment"
+      - add_ssh_keys:
+          fingerprints:
+            - "ca:d5:ac:60:67:ae:21:f9:8e:e7:7d:1b:3c:aa:78:c3"
       - run: yarn deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,14 +24,16 @@ commands:
     steps:
       - restore_cache:
           keys:
-          - yarn-<< parameters.image >>-<< parameters.version >>-{{ checksum "package.json" }}
-          - yarn-<< parameters.image >>-<< parameters.version >>
+            - yarn-<< parameters.image >>-<< parameters.version >>-{{ checksum "package.json" }}
+            - yarn-<< parameters.image >>-<< parameters.version >>
       - run: yarn install --frozen-lockfile
       - save_cache:
           paths:
             - ~/.cache
             - node_modules
-          key: yarn-{{ checksum "package.json" }}
+          keys:
+            - yarn-<< parameters.image >>-<< parameters.version >>-{{ checksum "package.json" }}
+            - yarn-<< parameters.image >>-<< parameters.version >>
 
 jobs:
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,6 @@ commands:
     parameters:
       image:
         type: string
-        default: "node"
       version:
         type: string
     steps:
@@ -57,5 +56,6 @@ jobs:
     steps:
       - checkout
       - install_dependencies:
+          image: "node"
           version: "3"
       - run: echo Hello world

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
-version: 2
+version: 2.1
+
 jobs:
   build:
     branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,14 +24,14 @@ commands:
     steps:
       - restore_cache:
           keys:
-          - v2-dependencies-2-<< parameters.image >>-<< parameters.version >>-{{ checksum "package.json" }}
-          - v2-dependencies-2-<< parameters.image >>-<< parameters.version >>
+          - yarn-<< parameters.image >>-<< parameters.version >>-{{ checksum "package.json" }}
+          - yarn-<< parameters.image >>-<< parameters.version >>
       - run: yarn install --frozen-lockfile
       - save_cache:
           paths:
             - ~/.cache
             - node_modules
-          key: v2-dependencies-2-{{ checksum "package.json" }}
+          key: yarn-{{ checksum "package.json" }}
 
 jobs:
   build_and_test:
@@ -42,7 +42,7 @@ jobs:
       - checkout
       - install_dependencies:
           image: "cypress"
-          version: "3"
+          version: "1"
       - run: yarn lint
       - run: yarn test
       - run:
@@ -57,5 +57,5 @@ jobs:
       - checkout
       - install_dependencies:
           image: "node"
-          version: "3"
+          version: "1"
       - run: echo Hello world

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,9 @@ jobs:
           background: true
       - run: yarn run wait-on http://localhost:6060 && yarn cypress run
   deploy:
+    docker:
+      - image: circleci/node:8.11.1
+    working_directory: ~/repo
     steps:
       - checkout
       - install_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,7 @@ commands:
           paths:
             - ~/.cache
             - node_modules
-          keys:
-            - yarn-<< parameters.image >>-<< parameters.version >>-{{ checksum "package.json" }}
-            - yarn-<< parameters.image >>-<< parameters.version >>
+          key: yarn-<< parameters.image >>-<< parameters.version >>-{{ checksum "package.json" }}
 
 jobs:
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,5 +63,5 @@ jobs:
           git config user.name "CI Deployment"
       - add_ssh_keys:
           fingerprints:
-            - "ca:d5:ac:60:67:ae:21:f9:8e:e7:7d:1b:3c:aa:78:c3"
+            - "79:26:19:57:4e:1a:59:64:ec:bb:b7:76:e2:5f:7c:ad"
       - run: yarn deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,13 @@ commands:
       image:
         type: string
         default: "node"
+      version:
+        type: string
     steps:
       - restore_cache:
           keys:
-          - v2-dependencies-2-<< parameters.image >>-{{ checksum "package.json" }}
-          - v2-dependencies-2-<< parameters.image >>
+          - v2-dependencies-2-<< parameters.image >>-<< parameters.version >>-{{ checksum "package.json" }}
+          - v2-dependencies-2-<< parameters.image >>-<< parameters.version >>
       - run: yarn install --frozen-lockfile
       - save_cache:
           paths:
@@ -41,6 +43,7 @@ jobs:
       - checkout
       - install_dependencies:
           image: "cypress"
+          version: "3"
       - run: yarn lint
       - run: yarn test
       - run:
@@ -53,5 +56,6 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - install_dependencies
+      - install_dependencies:
+          version: "3"
       - run: echo Hello world

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ workflows:
             branches:
               ignore:
                 - gh-pages
+      - deploy:
+          requires:
+            - build_and_test
 
 commands:
   install_dependencies:
@@ -39,3 +42,8 @@ jobs:
           command: yarn start
           background: true
       - run: yarn run wait-on http://localhost:6060 && yarn cypress run
+  deploy:
+    steps:
+      - checkout
+      - install_dependencies
+      - run: echo Hello world

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,4 +58,4 @@ jobs:
       - install_dependencies:
           image: "node"
           version: "1"
-      - run: echo Hello world
+      - run: yarn deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,15 @@ workflows:
 commands:
   install_dependencies:
     description: "Install dependencies with smart caching"
+    parameters:
+      image:
+        type: string
+        default: "node"
     steps:
       - restore_cache:
           keys:
-          - v2-dependencies-2-{{ checksum "package.json" }}
-          - v2-dependencies-2-
+          - v2-dependencies-2-<< parameters.image >>-{{ checksum "package.json" }}
+          - v2-dependencies-2-<< parameters.image >>
       - run: yarn install --frozen-lockfile
       - save_cache:
           paths:
@@ -35,7 +39,8 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - install_dependencies
+      - install_dependencies:
+          image: "cypress"
       - run: yarn lint
       - run: yarn test
       - run:


### PR DESCRIPTION
- Automatic GH pages deployment on successful `master` build

Note: this implies that Github Pages might always be ahead of a release. Perhaps a good follow up would be to indicate this in the Github page itself. Maybe offering a link to differences between `master` and latest release? 