### PR TITLE
Color re-organization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mavenlink/design-system",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Mavenlink React Components",
   "main": "src/index.js",
   "files": [

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -1,13 +1,24 @@
 :root {
+  /* Primary */
   --palette-primary: #448fea;
   --palette-primary-hover: #447bc6;
+
+  /* Action */
   --palette-action: #33ae10;
   --palette-action-hover: #328a15;
+
+  /* Highlight */
   --palette-highlight: #ff8400;
   --palette-highlight-hover: #ffa800;
+
+  /* Caution */
   --palette-caution: #e85342;
   --palette-caution-hover: #e53e2b;
+
+  /* Warning */
   --palette-warning: #ffdf8d;
+
+  /* Neutral */
   --palette-neutral-xx-dark: #282624;
   --palette-neutral-x-dark: #333333;
   --palette-neutral-dark: #4a4a4a;
@@ -18,6 +29,8 @@
   --palette-neutral-light: #e1e1dd;
   --palette-neutral-x-light: #f5f5f2;
   --palette-neutral-xx-light: #fbfaf6;
+
+  /* Primitives */
   --white: #fff;
   --black: #000;
 }

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -1,22 +1,42 @@
 :root {
-  /* Primary */
-  --palette-primary: #448fea;
+  /* Primary scale */
+  --palette-primary-dark: #1974e2;
+  --palette-primary-base: #448fea;
+  --palette-primary-light: #72aaef;
+
+  /* Primary interactions */
   --palette-primary-hover: #447bc6;
 
-  /* Action */
-  --palette-action: #33ae10;
+  /* Action scale */
+  --palette-action-dark: #257f0c;
+  --palette-action-base: #33ae10;
+  --palette-action-light: #41dd14;
+
+  /* Action interactions */
   --palette-action-hover: #328a15;
 
-  /* Highlight */
-  --palette-highlight: #ff8400;
+  /* Highlight scale */
+  --palette-highlight-dark: #cc6a00;
+  --palette-highlight-base: #ff8400;
+  --palette-highlight-light: #ff9d33;
+
+  /* Highlight interactions */
   --palette-highlight-hover: #ffa800;
 
-  /* Caution */
-  --palette-caution: #e85342;
+  /* Caution scale */
+  --palette-caution-dark: #dc2f1b;
+  --palette-caution-base: #e85342;
+  --palette-caution-light: #ee7c6f;
+
+  /* Caution interactions */
   --palette-caution-hover: #e53e2b;
 
-  /* Warning */
-  --palette-warning: #ffdf8d;
+  /* Warning scale */
+  --palette-warning-dark: #ffd15a;
+  --palette-warning-base: #ffdf8d;
+  --palette-warning-light: #ffedc0;
+  /* Warning interactions */
+  --palette-warning-hover: #ffd874;
 
   /* Neutral */
   --palette-neutral-xx-dark: #282624;


### PR DESCRIPTION
Adds the missing colors from our palette. We are explicitly avoiding porting "product" colors since those are application specific. 

The colors will change in the near future as well when we collaborate with the design team. 