### PR TITLE
Implement Github PR template to make it easier to start a new PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,7 @@
 Type of work: bug / component / site / accessibility / other
+
 Deployment URL: https://mavenlink.gihub.io/design-system/$BRANCH
+
 (Optional for outside contributions) Tracked work in Mavenlink:
 
 ## Motivation

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+Type of work: bug / component / site / accessibility / other
+Deployment URL: https://mavenlink.gihub.io/design-system/$BRANCH
+(Optional for outside contributions) Tracked work in Mavenlink:
+
+## Motivation
+
+<!-- This section is reserved for reasoning and historical context on the proposed change set -->
+<!-- END MOTIVIATION-->
+
+## Acceptance Criteria
+
+<!-- This section is reserved for documenting the qualifiers for accepting the PR (besides a green build) -->
+<!-- END ACCEPTANCE CRITERIA -->


### PR DESCRIPTION
Type of work: other
Deployment URL: Not applicable
(Optional for outside contributions) Tracked work in Mavenlink: https://www.pivotaltracker.com/story/show/167446043

## Motivation

<!-- This section is reserved for reasoning and historical context on the proposed change set -->
This makes it easier to ensure we are providing the appropriate documentation on a new PR. Especially the reasoning for changes and double checking the acceptance criteria for PRs. 

I got the instruction off of https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository
<!-- END MOTIVIATION-->

## Acceptance Criteria

<!-- This section is reserved for documenting the qualifiers for accepting the PR (besides a green build) -->
Test PR after this PR to see if it auto-populates.
<!-- END ACCEPTANCE CRITERIA -->
