### PR TITLE
IE11 support on MDS site

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/plugin-proposal-class-properties": "^7.2.3",
+    "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "^7.2.3",
     "@babel/preset-react": "^7.0.0",
     "babel-core": "^7.0.0-bridge.0",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -17,6 +17,7 @@ module.exports = {
   },
   pagePerSection: true,
   require: [
+    '@babel/polyfill',
     './styleguide/content/content.css',
   ],
   sections: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -500,6 +500,13 @@
     "@babel/helper-regex" "^7.0.0"
     regexpu-core "^4.1.3"
 
+"@babel/polyfill@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.4.4.tgz#78801cf3dbe657844eeabf31c1cae3828051e893"
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
+
 "@babel/preset-env@^7.2.3":
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.2.3.tgz#948c8df4d4609c99c7e0130169f052ea6a7a8933"
@@ -2084,6 +2091,10 @@ copy-webpack-plugin@^4.5.4:
 core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.1.tgz#87416ae817de957a3f249b3b5ca475d4aaed6042"
+
+core-js@^2.6.5:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -7074,6 +7085,10 @@ regenerator-runtime@^0.11.0:
 regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+
+regenerator-runtime@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
 
 regenerator-transform@^0.13.3:
   version "0.13.3"


### PR DESCRIPTION
Type of work: site

Deployment URL: https://mavenlink.github.io/design-system/ie11-support

(Optional for outside contributions) Tracked work in Mavenlink: https://www.pivotaltracker.com/story/show/167441913

## Motivation

<!-- This section is reserved for reasoning and historical context on the proposed change set -->
Includes `@babel/polyfill` as its own entry in MDS site. This ensures the site loads on IE11. We can now test components and accessibility in IE11!
<!-- END MOTIVIATION-->

## Acceptance Criteria

<!-- This section is reserved for documenting the qualifiers for accepting the PR (besides a green build) -->
- [x] Site loads on IE11
- [x] Site loads on Edge
- [x] Site loads on Chrome
- [x] Site loads on Firefox
- [x] Site loads on Safari
<!-- END ACCEPTANCE CRITERIA -->
