### PR TITLE
Fix typo in deployment URL

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Type of work: bug / component / site / accessibility / other
 
-Deployment URL: https://mavenlink.gihub.io/design-system/$BRANCH
+Deployment URL: https://mavenlink.github.io/design-system/$BRANCH
 
 (Optional for outside contributions) Tracked work in Mavenlink:
 


### PR DESCRIPTION
Type of work: other

Deployment URL: https://mavenlink.github.io/design-system/master

(Optional for outside contributions) Tracked work in Mavenlink: No. Fast patch.

## Motivation

<!-- This section is reserved for reasoning and historical context on the proposed change set -->
Deployment URL has a typo. We need to fix it.
<!-- END MOTIVIATION-->

## Acceptance Criteria

<!-- This section is reserved for documenting the qualifiers for accepting the PR (besides a green build) -->
Deplyoment URL should work if you replace `$BRANCH` with `master`
<!-- END ACCEPTANCE CRITERIA -->
