### PR TITLE
Let us never forget the change log entry

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,3 +13,8 @@ Deployment URL: https://mavenlink.github.io/design-system/$BRANCH
 
 <!-- This section is reserved for documenting the qualifiers for accepting the PR (besides a green build) -->
 <!-- END ACCEPTANCE CRITERIA -->
+
+## Change log entry
+
+<!-- This section is reserved for change log entry. We need to copy this to the CHANGELOG.md file before merging -->
+<!-- END CHANGE LOG ENTRY -->


### PR DESCRIPTION
Type of work: other

Deployment URL: N/A

(Optional for outside contributions) Tracked work in Mavenlink: N/A

## Motivation

<!-- This section is reserved for reasoning and historical context on the proposed change set -->
I forgot the change log entry recently. Theoretically, every PR that impacts the published assets much have an entry. This PR section helps us for those kinds of PRs.

Ideally, we want to automate this somehow -- perhaps merge commit => change log entry? 
<!-- END MOTIVIATION-->

## Acceptance Criteria

<!-- This section is reserved for documenting the qualifiers for accepting the PR (besides a green build) -->
Next PR should have the change log entry section
<!-- END ACCEPTANCE CRITERIA -->
