### PR TITLE
Button API: id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mavenlink/design-system",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Mavenlink React Components",
   "main": "src/index.js",
   "files": [
@@ -70,13 +70,13 @@
     "react-styleguidist": "^8.0.6",
     "react-transition-group": "^2.5.3",
     "style-loader": "^0.23.1",
-    "svg-sprite-loader": "^3.8.0",
-    "svgo": "^1.3,0",
-    "svgo-loader": "^2.1.0",
     "stylelint": "^10.1.0",
     "stylelint-config-css-modules": "^1.4.0",
     "stylelint-config-standard": "^18.3.0",
     "stylelint-css-modules": "^0.9.0",
+    "svg-sprite-loader": "^3.8.0",
+    "svgo": "^1.3,0",
+    "svgo-loader": "^2.1.0",
     "url-loader": "^1.1.2",
     "wait-on": "^3.2.0",
     "webpack": "^4.28.3"

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -7,6 +7,7 @@ export default function Button(props) {
     <button
       className={props.className || styles[props.color]}
       disabled={props.disabled}
+      id={props.id}
       onClick={props.onClick}
       type={props.type}
     >
@@ -23,6 +24,7 @@ Button.propTypes = {
   ]),
   children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
+  id: PropTypes.string,
   onClick: PropTypes.func,
   type: PropTypes.oneOf([
     'button',
@@ -35,6 +37,7 @@ Button.defaultProps = {
   className: undefined,
   color: 'primary',
   disabled: undefined,
+  id: undefined,
   onClick: () => {},
   type: undefined,
 };

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -3,23 +3,14 @@ import React from 'react';
 import styles from './button.css';
 
 export default function Button(props) {
-  const {
-    children,
-    className,
-    color,
-    disabled,
-    onClick,
-    type,
-  } = props;
-
   return (
     <button
-      className={className || styles[color]}
-      disabled={disabled}
-      onClick={onClick}
-      type={type}
+      className={props.className || styles[props.color]}
+      disabled={props.disabled}
+      onClick={props.onClick}
+      type={props.type}
     >
-      {children}
+      {props.children}
     </button>
   );
 }

--- a/src/components/button/button.test.jsx
+++ b/src/components/button/button.test.jsx
@@ -72,6 +72,17 @@ describe('Button', () => {
     });
   });
 
+  describe('id API', () => {
+    it('sets the id attribute', () => {
+      const tree = renderer.create((
+        <Button id="test-id">
+          Hello world!
+        </Button>
+      )).toJSON();
+      expect(tree.props.id).toEqual('test-id');
+    });
+  });
+
   describe('onClick API', () => {
     it('sets the onclick handler', () => {
       const onClickSpy = jest.fn();


### PR DESCRIPTION
- Type of work: component
- Deployment URL: https://mavenlink.github.io/design-system/button-prop-id
- (Optional for outside contributions) Tracked work in Mavenlink: https://www.pivotaltracker.com/story/show/167495817

## Motivation

<!-- This section is reserved for reasoning and historical context on the proposed change set -->
Our legacy stack uses global IDs to search for elements on the DOM tree. Exposing the ID attribute will help us migrate into a better React ecosystem.
<!-- END MOTIVIATION-->

## Acceptance Criteria

<!-- This section is reserved for documenting the qualifiers for accepting the PR (besides a green build) -->
- Prop can be set in the deployment site
- Prop is documented in the deployment site
<!-- END ACCEPTANCE CRITERIA -->

## Change log entry

<!-- This section is reserved for change log entry. We need to copy this to the CHANGELOG.md file before merging -->
Minor enhancement: add `id` prop to button
<!-- END CHANGE LOG ENTRY -->
