### PR TITLE
Update Github pages job to deal with nested folders due to branch names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
             git checkout gh-pages
             rm -rf $CIRCLE_BRANCH
             mkdir -p $CIRCLE_BRANCH
-            mv -v dist/* $CIRCLE_BRANCH
+            mv -v build/* $CIRCLE_BRANCH
             git add .
             git diff-index --quiet HEAD || git commit -m 'Update Github pages for $CIRCLE_BRANCH'
             git push origin gh-pages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,8 @@ jobs:
             yarn build
             git checkout gh-pages
             rm -rf $CIRCLE_BRANCH
-            mv build $CIRCLE_BRANCH
+            mkdir -p $CIRCLE_BRANCH
+            mv -v dist/* $CIRCLE_BRANCH
             git add .
             git diff-index --quiet HEAD || git commit -m 'Update Github pages for $CIRCLE_BRANCH'
             git push origin gh-pages


### PR DESCRIPTION
Type of work: other

Deployment URL: https://mavenlink.github.io/design-system/test/ghpages/dependabot

(Optional for outside contributions) Tracked work in Mavenlink:

## Motivation

<!-- This section is reserved for reasoning and historical context on the proposed change set -->
With automatic fixes from dependabot, we need to ensure our infrastructure can accommodate its weird branch naming schemes. We were not able to deal with branch names with forward slashes because our `mv` command thought it needed find subfolders. 
<!-- END MOTIVIATION-->

## Acceptance Criteria

<!-- This section is reserved for documenting the qualifiers for accepting the PR (besides a green build) -->
Deployment URL should work above!
<!-- END ACCEPTANCE CRITERIA -->

## Change log entry

<!-- This section is reserved for change log entry. We need to copy this to the CHANGELOG.md file before merging -->
<!-- END CHANGE LOG ENTRY -->
