### PR TITLE
The start of honeybee tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mavenlink/design-system",
-  "version": "0.10.0-table-v2",
+  "version": "0.11.0",
   "description": "Mavenlink React Components",
   "main": "src/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mavenlink/design-system",
-  "version": "0.10.0",
+  "version": "0.10.0-table-v2",
   "description": "Mavenlink React Components",
   "main": "src/index.js",
   "files": [

--- a/src/components/table/table.css
+++ b/src/components/table/table.css
@@ -40,6 +40,7 @@
 .headerCell {
   composes: cell;
   font-size: var(--mavenlink-type-small-size);
+  text-align: left;
   vertical-align: bottom;
   color: var(--palette-grey-dark);
 }

--- a/src/components/table/table.css
+++ b/src/components/table/table.css
@@ -34,6 +34,7 @@
   padding: var(--spacing-medium);
   font-size: var(--mavenlink-type-base-size);
   vertical-align: top;
+  color: var(--palette-grey-x-dark);
 }
 
 .headerCell {

--- a/src/components/table/table.css
+++ b/src/components/table/table.css
@@ -18,29 +18,27 @@
 }
 
 .head {
-  background: var(--palette-neutral-xx-light);
-  border-bottom: 1px solid var(--palette-neutral-light);
-  border-top: 1px solid var(--palette-neutral-light);
+  background: var(--palette-grey-x-light);
+  border-bottom: 1px solid var(--palette-grey-light);
   box-sizing: border-box;
 }
 
 .row {
-  border-bottom: 1px solid var(--palette-neutral-light);
+  border-bottom: 1px solid var(--palette-grey-light);
   box-sizing: border-box;
 }
 
 .cell {
   box-sizing: border-box;
   font-weight: normal;
-  line-height: 1.8;
-  padding-left: var(--spacing-medium);
+  padding: var(--spacing-medium);
+  font-size: var(--mavenlink-type-base-size);
+  vertical-align: top;
 }
 
 .headerCell {
   composes: cell;
-  border-right: 1px solid var(--palette-neutral-light);
-}
-
-.headerCell:last-child {
-  border-right: none;
+  font-size: var(--mavenlink-type-small-size);
+  vertical-align: bottom;
+  color: var(--palette-grey-dark);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,2 @@
-export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableRow,
-  TableCell,
-  TableHeaderCell,
-} from './components/table/index.js';
+// We do not re-export our components because we would like individual references to our component files.
+// Individual references to our files allows for better static analysis.

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -11,8 +11,7 @@
   --mavenlink-type-base-size: 14px;
   --mavenlink-type-small-size: 12px;
   --mavenlink-type-button-font-size: var(--mavenlink-type-base-size);
-  --mavenlink-type-body-font-size: 12px;
   --mavenlink-type-text-rendering: optimizeLegibility;
-  --mavenlink-type-line-height: 1.5;
+  --mavenlink-type-line-height: 1;
   --mavenlink-type-header-line-height: 1.2;
 }


### PR DESCRIPTION
Simple table design, new colors, padding, font sizes. Deleted body font-size variable, base font-size variable was the same, and base variable should be used.

Co-Authored-By: Juan Carlos Medina <juanca@users.noreply.github.com>

Type of work: component

Deployment URL: https://mavenlink.github.io/design-system/honeybee-tables

(Optional for outside contributions) Tracked work in Mavenlink: https://www.pivotaltracker.com/story/show/168525085

## Motivation

To make tables awesome and apply new consistency designs to tables.

<!-- This section is reserved for reasoning and historical context on the proposed change set -->
<!-- END MOTIVIATION-->

## Acceptance Criteria

Table header
- Text is lighter gray then table body text
- Light gray background with border on bottom

Table body
- Text is "black" (87% black)

<!-- This section is reserved for documenting the qualifiers for accepting the PR (besides a green build) -->
<!-- END ACCEPTANCE CRITERIA -->

## Change log entry

<!-- This section is reserved for change log entry. We need to copy this to the CHANGELOG.md file before merging -->
<!-- END CHANGE LOG ENTRY -->
