### PR TITLE
Add a new Custom Field centric Text Input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
     Changes that have landed in master but are not yet released.
     Click to see more.
   </summary>
+
+  - Implement a text input field designed for custom forms
 </details>
 
 ## 0.9.0 (July 24, 2019)

--- a/src/components/custom-field-input-text/__snapshots__/custom-field-input-text.test.jsx.snap
+++ b/src/components/custom-field-input-text/__snapshots__/custom-field-input-text.test.jsx.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CustomFieldInputText has defaults 1`] = `
+<div
+  className="custom-field-input-text"
+>
+  <div
+    className="heading-container"
+  >
+    <label
+      className="label"
+    >
+      Input Descriptor
+    </label>
+    <span
+      className="additional-information-icon"
+    >
+      ?
+    </span>
+  </div>
+  <div
+    className="input-container"
+  >
+    <input
+      disabled={false}
+      onClick={[Function]}
+      type="text"
+    />
+  </div>
+  <span
+    className="help"
+  />
+</div>
+`;

--- a/src/components/custom-field-input-text/__snapshots__/custom-field-input-text.test.jsx.snap
+++ b/src/components/custom-field-input-text/__snapshots__/custom-field-input-text.test.jsx.snap
@@ -17,6 +17,7 @@ exports[`CustomFieldInputText has defaults 1`] = `
     className="input-container"
   >
     <input
+      className="input"
       disabled={false}
       onClick={[Function]}
       type="text"

--- a/src/components/custom-field-input-text/__snapshots__/custom-field-input-text.test.jsx.snap
+++ b/src/components/custom-field-input-text/__snapshots__/custom-field-input-text.test.jsx.snap
@@ -12,11 +12,6 @@ exports[`CustomFieldInputText has defaults 1`] = `
     >
       Input Descriptor
     </label>
-    <span
-      className="additional-information-icon"
-    >
-      ?
-    </span>
   </div>
   <div
     className="input-container"

--- a/src/components/custom-field-input-text/custom-field-input-text.css
+++ b/src/components/custom-field-input-text/custom-field-input-text.css
@@ -24,12 +24,7 @@
   color: var(--palette-caution-base);
 }
 
-.input-container {
-  height: 34px;
-  margin: var(--spacing-small) 0;
-}
-
-input {
+.input {
   border: 1px solid var(--palette-grey-light);
   border-radius: var(--spacing-x-small);
   color: var(--palette-grey-x-dark);
@@ -37,17 +32,22 @@ input {
   padding: var(--spacing-medium);
 }
 
-.input-container input::placeholder {
-  color: var(--palette-grey-dark);
-}
-
-.disabled input {
+.disabled .input {
   background-color: var(--palette-grey-light);
 }
 
-.error input {
+.error .input {
   border-color: var(--palette-caution-base);
   padding-right: var(--spacing-x-large);
+}
+
+.input-container {
+  height: 34px;
+  margin: var(--spacing-small) 0;
+}
+
+.input-container input::placeholder {
+  color: var(--palette-grey-dark);
 }
 
 .input-icon-container {

--- a/src/components/custom-field-input-text/custom-field-input-text.css
+++ b/src/components/custom-field-input-text/custom-field-input-text.css
@@ -8,7 +8,7 @@
 
 .heading-container {
   color: var(--palette-grey-dark);
-  font-size: var(--mavenlink-type-body-font-size);
+  font-size: var(--mavenlink-type-small-size);
 }
 
 .error .heading-container {

--- a/src/components/custom-field-input-text/custom-field-input-text.css
+++ b/src/components/custom-field-input-text/custom-field-input-text.css
@@ -9,9 +9,7 @@
   cursor: pointer;
   display: inline-block;
   height: var(--spacing-large);
-  left: var(--spacing-medium);
-  padding-left: 1px;
-  position: relative;
+  margin-left: var(--spacing-medium);
   text-align: center;
   width: var(--spacing-large);
 }

--- a/src/components/custom-field-input-text/custom-field-input-text.css
+++ b/src/components/custom-field-input-text/custom-field-input-text.css
@@ -2,18 +2,6 @@
 @import '../../styles/spacing.css';
 @import '../../styles/typography.css';
 
-.additional-information-icon {
-  border: 1px solid var(--palette-grey-light);
-  border-radius: 50%;
-  color: var(--palette-grey-dark);
-  cursor: pointer;
-  display: inline-block;
-  height: var(--spacing-large);
-  margin-left: var(--spacing-medium);
-  text-align: center;
-  width: var(--spacing-large);
-}
-
 .custom-field-input-text {
   font-family: var(--mavenlink-type-font-family);
 }

--- a/src/components/custom-field-input-text/custom-field-input-text.css
+++ b/src/components/custom-field-input-text/custom-field-input-text.css
@@ -1,0 +1,84 @@
+@import '../../styles/colors.css';
+@import '../../styles/spacing.css';
+@import '../../styles/typography.css';
+
+.additional-information-icon {
+  border: 1px solid var(--palette-grey-light);
+  border-radius: 50%;
+  color: var(--palette-grey-dark);
+  cursor: pointer;
+  display: inline-block;
+  height: var(--spacing-large);
+  left: var(--spacing-medium);
+  padding-left: 1px;
+  position: relative;
+  text-align: center;
+  width: var(--spacing-large);
+}
+
+.custom-field-input-text {
+  font-family: var(--mavenlink-type-font-family);
+}
+
+.heading-container {
+  color: var(--palette-grey-dark);
+  font-size: var(--mavenlink-type-body-font-size);
+}
+
+.error .heading-container {
+  color: var(--palette-caution-base);
+}
+
+.help {
+  color: var(--palette-grey-dark);
+  font-size: var(--mavenlink-type-base-size);
+}
+
+.error .help {
+  color: var(--palette-caution-base);
+}
+
+.input-container {
+  height: 34px;
+  margin: var(--spacing-small) 0;
+}
+
+.input-container input {
+  border: 1px solid var(--palette-grey-light);
+  border-radius: var(--spacing-x-small);
+  color: var(--palette-grey-x-dark);
+  font-size: var(--mavenlink-type-base-size);
+  padding: var(--spacing-medium);
+}
+
+.input-container input::placeholder {
+  color: var(--palette-grey-dark);
+}
+
+.disabled .input-container input {
+  background-color: var(--palette-grey-light);
+}
+
+.error .input-container input {
+  border-color: var(--palette-caution-base);
+}
+
+.input-icon-container {
+  background-color: var(--white);
+  display: inline-block;
+  height: 20px;
+  position: absolute;
+  margin-left: -28px;
+  margin-top: var(--spacing-small);
+  width: 20px;
+}
+
+.label {
+  margin-right: var(--spacing-small);
+}
+
+.optional {
+  display: inline-block;
+  margin-right: var(--spacing-small);
+  min-width: 30px;
+}

--- a/src/components/custom-field-input-text/custom-field-input-text.css
+++ b/src/components/custom-field-input-text/custom-field-input-text.css
@@ -47,6 +47,7 @@
   color: var(--palette-grey-x-dark);
   font-size: var(--mavenlink-type-base-size);
   padding: var(--spacing-medium);
+  padding-right: var(--spacing-x-large);
 }
 
 .input-container input::placeholder {

--- a/src/components/custom-field-input-text/custom-field-input-text.css
+++ b/src/components/custom-field-input-text/custom-field-input-text.css
@@ -41,7 +41,7 @@
   margin: var(--spacing-small) 0;
 }
 
-.input-container input {
+input {
   border: 1px solid var(--palette-grey-light);
   border-radius: var(--spacing-x-small);
   color: var(--palette-grey-x-dark);
@@ -54,11 +54,11 @@
   color: var(--palette-grey-dark);
 }
 
-.disabled .input-container input {
+.disabled input {
   background-color: var(--palette-grey-light);
 }
 
-.error .input-container input {
+.error input {
   border-color: var(--palette-caution-base);
 }
 

--- a/src/components/custom-field-input-text/custom-field-input-text.css
+++ b/src/components/custom-field-input-text/custom-field-input-text.css
@@ -47,7 +47,6 @@ input {
   color: var(--palette-grey-x-dark);
   font-size: var(--mavenlink-type-base-size);
   padding: var(--spacing-medium);
-  padding-right: var(--spacing-x-large);
 }
 
 .input-container input::placeholder {
@@ -60,6 +59,7 @@ input {
 
 .error input {
   border-color: var(--palette-caution-base);
+  padding-right: var(--spacing-x-large);
 }
 
 .input-icon-container {

--- a/src/components/custom-field-input-text/custom-field-input-text.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.jsx
@@ -25,7 +25,7 @@ export default function CustomFieldInputText(props) {
         {props.required && <span className={styles.optional}>(Required)</span>}
       </div>
       <div className={styles['input-container']}>
-        <input className={styles.input} type="text" id={props.id} name={props.name} placeholder={props.placeholder} value={props.value} onClick={props.onClick} disabled={props.disabled} />
+        <input className={styles.input} disabled={props.disabled} type="text" id={props.id} name={props.name} placeholder={props.placeholder} value={props.value} onClick={props.onClick} />
         {props.error &&
           <div className={styles['input-icon-container']}>
             <Icon className={styles['input-icon']} currentColor="caution" name={cautionSvg.id} size="medium" />

--- a/src/components/custom-field-input-text/custom-field-input-text.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.jsx
@@ -23,7 +23,6 @@ export default function CustomFieldInputText(props) {
       <div className={styles['heading-container']}>
         <label className={styles.label} htmlFor={props.id}>Input Descriptor</label>
         {props.required && <span className={styles.optional}>(Required)</span>}
-        <span className={styles['additional-information-icon']}>?</span>
       </div>
       <div className={styles['input-container']}>
         <input type="text" id={props.id} name={props.name} placeholder={props.placeholder} value={props.value} onClick={props.onClick} disabled={props.disabled} />

--- a/src/components/custom-field-input-text/custom-field-input-text.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.jsx
@@ -25,7 +25,7 @@ export default function CustomFieldInputText(props) {
         {props.required && <span className={styles.optional}>(Required)</span>}
       </div>
       <div className={styles['input-container']}>
-        <input type="text" id={props.id} name={props.name} placeholder={props.placeholder} value={props.value} onClick={props.onClick} disabled={props.disabled} />
+        <input className={styles.input} type="text" id={props.id} name={props.name} placeholder={props.placeholder} value={props.value} onClick={props.onClick} disabled={props.disabled} />
         {props.error &&
           <div className={styles['input-icon-container']}>
             <Icon className={styles['input-icon']} currentColor="caution" name={cautionSvg.id} size="medium" />

--- a/src/components/custom-field-input-text/custom-field-input-text.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.jsx
@@ -6,17 +6,15 @@ import Icon from '../icon/icon.jsx';
 import styles from './custom-field-input-text.css';
 
 function getRootClassName(className, error, disabled) {
-  const resolvedClassName = className || styles['custom-field-input-text'];
-
   if (disabled) {
-    return `${resolvedClassName} ${styles.disabled}`;
+    return `${className} ${styles.disabled}`;
   }
 
   if (error) {
-    return `${resolvedClassName} ${styles.error}`;
+    return `${className} ${styles.error}`;
   }
 
-  return resolvedClassName;
+  return className;
 }
 
 export default function CustomFieldInputText(props) {
@@ -54,7 +52,7 @@ CustomFieldInputText.propTypes = {
 };
 
 CustomFieldInputText.defaultProps = {
-  className: undefined,
+  className: styles['custom-field-input-text'],
   disabled: false,
   error: false,
   helpText: undefined,

--- a/src/components/custom-field-input-text/custom-field-input-text.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.jsx
@@ -1,0 +1,67 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import cautionSvg from '../../svgs/icon-caution-fill.svg';
+import Icon from '../icon/icon.jsx';
+import styles from './custom-field-input-text.css';
+
+function getRootClassName(className, error, disabled) {
+  const resolvedClassName = className || styles['custom-field-input-text'];
+
+  if (disabled) {
+    return `${resolvedClassName} ${styles.disabled}`;
+  }
+
+  if (error) {
+    return `${resolvedClassName} ${styles.error}`;
+  }
+
+  return resolvedClassName;
+}
+
+export default function CustomFieldInputText(props) {
+  return (
+    <div className={getRootClassName(props.className, props.error, props.disabled)}>
+      <div className={styles['heading-container']}>
+        <label className={styles.label} htmlFor={props.id}>Input Descriptor</label>
+        {props.required && <span className={styles.optional}>(Required)</span>}
+        <span className={styles['additional-information-icon']}>?</span>
+      </div>
+      <div className={styles['input-container']}>
+        <input type="text" id={props.id} name={props.name} placeholder={props.placeholder} value={props.value} onClick={props.onClick} disabled={props.disabled} />
+        {props.error &&
+          <div className={styles['input-icon-container']}>
+            <Icon className={styles['input-icon']} currentColor="caution" name={cautionSvg.id} size="medium" />
+          </div>
+        }
+      </div>
+      <span className={styles.help}>{props.helpText}</span>
+    </div>
+  );
+}
+
+CustomFieldInputText.propTypes = {
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  error: PropTypes.bool,
+  helpText: PropTypes.string,
+  id: PropTypes.string,
+  name: PropTypes.string,
+  onClick: PropTypes.func,
+  placeholder: PropTypes.string,
+  required: PropTypes.bool,
+  value: PropTypes.string,
+};
+
+CustomFieldInputText.defaultProps = {
+  className: undefined,
+  disabled: false,
+  error: false,
+  helpText: undefined,
+  id: undefined,
+  name: undefined,
+  onClick: () => {},
+  placeholder: undefined,
+  required: false,
+  value: undefined,
+};

--- a/src/components/custom-field-input-text/custom-field-input-text.md
+++ b/src/components/custom-field-input-text/custom-field-input-text.md
@@ -1,0 +1,31 @@
+```jsx
+<CustomFieldInputText
+  helpText="This is help text!"
+  id="test-id-1"
+  name="test-name-1"
+  placeholder="This is a placeholder value"
+  required={true}
+/>
+```
+----
+##### Disabled:
+```jsx
+<CustomFieldInputText
+  disabled={true}
+  helpText="This input is disabled."
+  id="test-id-2"
+  name="test-name-2"
+  value="This value cannot be changed"
+/>
+```
+----
+##### Error:
+```jsx
+<CustomFieldInputText
+  error={true}
+  helpText="This input is bad."
+  id="test-id-3"
+  name="test-name-3"
+  value="For some reason, this input doesn't pass validation @@1112#&&&&!@*&!&@!"
+/>
+```

--- a/src/components/custom-field-input-text/custom-field-input-text.test.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.test.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import CustomFieldInputText from './custom-field-input-text.jsx';
+
+describe('CustomFieldInputText', () => {
+  it('has defaults', () => {
+    const tree = renderer.create((
+      <CustomFieldInputText />
+    )).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  describe('className API', () => {
+    it('prioritizes className prop', () => {
+      const tree = renderer.create((
+        <CustomFieldInputText className="prioritize-me" />
+      )).toJSON();
+      expect(tree.props.className).toEqual('prioritize-me');
+    });
+  });
+
+  describe('disabled API', () => {
+    it('can be disabled', () => {
+      const tree = renderer.create((
+        <CustomFieldInputText disabled={true} />
+      )).root;
+      expect(tree.findByProps({ disabled: true })).toBeTruthy();
+    });
+
+    it('can be enabled', () => {
+      const tree = renderer.create((
+        <CustomFieldInputText disabled={false} />
+      )).root;
+      expect(tree.findByProps({ disabled: false })).toBeTruthy();
+    });
+  });
+
+  describe('name API', () => {
+    it('sets the name attribute', () => {
+      const tree = renderer.create((
+        <CustomFieldInputText name="test-name" />
+      )).root;
+      expect(tree.findByProps({ name: 'test-name' })).toBeTruthy();
+    });
+  });
+
+  describe('id API', () => {
+    it('sets the id attribute', () => {
+      const tree = renderer.create((
+        <CustomFieldInputText id="test-id" />
+      )).root;
+      expect(tree.findByProps({ id: 'test-id' })).toBeTruthy();
+    });
+  });
+
+  describe('onClick API', () => {
+    it('sets the onclick handler', () => {
+      const onClickSpy = jest.fn();
+      const tree = renderer.create((
+        <CustomFieldInputText onClick={onClickSpy} />
+      )).root;
+      tree.findByType('input').props.onClick();
+      expect(onClickSpy.mock.calls.length).toEqual(1);
+    });
+  });
+
+  describe('value API', () => {
+    it('sets the value attribute', () => {
+      const tree = renderer.create((
+        <CustomFieldInputText value="test-value" />
+      )).root;
+      expect(tree.findByProps({ value: 'test-value' })).toBeTruthy();
+    });
+  });
+});

--- a/src/components/custom-field-input-text/custom-field-input-text.test.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.test.jsx
@@ -67,6 +67,27 @@ describe('CustomFieldInputText', () => {
     });
   });
 
+  describe('help text API', () => {
+    it('can have help text', () => {
+      const helpText = 'Oh wow big helpful yes!';
+      const r = renderer.create((
+        <CustomFieldInputText helpText={helpText} />
+      ));
+      const root = r.root;
+
+      expect(root.findByProps({ className: 'help' }).children).toContain(helpText);
+    });
+
+    it('can have empty help text', () => {
+      const r = renderer.create((
+        <CustomFieldInputText />
+      ));
+      const root = r.root;
+
+      expect(root.findByProps({ className: 'help' }).children).toEqual([]);
+    });
+  });
+
   describe('name API', () => {
     it('sets the name attribute', () => {
       const tree = renderer.create((

--- a/src/components/custom-field-input-text/custom-field-input-text.test.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.test.jsx
@@ -97,6 +97,27 @@ describe('CustomFieldInputText', () => {
     });
   });
 
+  describe('placeholder API', () => {
+    it('can have placeholder for input', () => {
+      const placeholder = 'This is placeholder input';
+      const r = renderer.create((
+        <CustomFieldInputText placeholder={placeholder} />
+      ));
+      const root = r.root;
+
+      expect(root.findByType('input').props.placeholder).toEqual(placeholder);
+    });
+
+    it('can have no placeholder for input', () => {
+      const r = renderer.create((
+        <CustomFieldInputText />
+      ));
+      const root = r.root;
+
+      expect(root.findByType('input').props.placeholder).toBeUndefined();
+    });
+  });
+
   describe('id API', () => {
     it('sets the id attribute', () => {
       const tree = renderer.create((

--- a/src/components/custom-field-input-text/custom-field-input-text.test.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.test.jsx
@@ -24,14 +24,16 @@ describe('CustomFieldInputText', () => {
       const tree = renderer.create((
         <CustomFieldInputText disabled={true} />
       )).root;
-      expect(tree.findByProps({ disabled: true })).toBeTruthy();
+      expect(tree.findByProps({ className: 'custom-field-input-text' }).findByProps({ disabled: true }));
+      expect(tree.findByType('input').findByProps({ disabled: true }));
     });
 
     it('can be enabled', () => {
       const tree = renderer.create((
         <CustomFieldInputText disabled={false} />
       )).root;
-      expect(tree.findByProps({ disabled: false })).toBeTruthy();
+      expect(tree.findByProps({ className: 'custom-field-input-text' }).findByProps({ disabled: false }));
+      expect(tree.findByType('input').findByProps({ disabled: false }));
     });
   });
 
@@ -40,7 +42,7 @@ describe('CustomFieldInputText', () => {
       const tree = renderer.create((
         <CustomFieldInputText name="test-name" />
       )).root;
-      expect(tree.findByProps({ name: 'test-name' })).toBeTruthy();
+      expect(tree.findByType('input').findByProps({ name: 'test-name' }));
     });
   });
 
@@ -49,7 +51,7 @@ describe('CustomFieldInputText', () => {
       const tree = renderer.create((
         <CustomFieldInputText id="test-id" />
       )).root;
-      expect(tree.findByProps({ id: 'test-id' })).toBeTruthy();
+      expect(tree.findByType('input').findByProps({ id: 'test-id' }));
     });
   });
 
@@ -69,7 +71,7 @@ describe('CustomFieldInputText', () => {
       const tree = renderer.create((
         <CustomFieldInputText value="test-value" />
       )).root;
-      expect(tree.findByProps({ value: 'test-value' })).toBeTruthy();
+      expect(tree.findByType('input').findByProps({ value: 'test-value' }));
     });
   });
 });

--- a/src/components/custom-field-input-text/custom-field-input-text.test.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.test.jsx
@@ -21,19 +21,49 @@ describe('CustomFieldInputText', () => {
 
   describe('disabled API', () => {
     it('can be disabled', () => {
-      const tree = renderer.create((
+      const r = renderer.create((
         <CustomFieldInputText disabled={true} />
-      )).root;
-      expect(tree.findByProps({ className: 'custom-field-input-text' }).findByProps({ disabled: true }));
-      expect(tree.findByType('input').findByProps({ disabled: true }));
+      ));
+      const tree = r.toJSON();
+      const root = r.root;
+
+      expect(tree.props.className).toContain('disabled');
+      expect(root.findByType('input').findByProps({ disabled: true }));
     });
 
     it('can be enabled', () => {
-      const tree = renderer.create((
+      const r = renderer.create((
         <CustomFieldInputText disabled={false} />
-      )).root;
-      expect(tree.findByProps({ className: 'custom-field-input-text' }).findByProps({ disabled: false }));
-      expect(tree.findByType('input').findByProps({ disabled: false }));
+      ));
+      const tree = r.toJSON();
+      const root = r.root;
+
+      expect(tree.props.className).not.toContain('disabled');
+      expect(root.findByType('input').findByProps({ disabled: false }));
+    });
+  });
+
+  describe('error API', () => {
+    it('can have an error state', () => {
+      const r = renderer.create((
+        <CustomFieldInputText error={true} />
+      ));
+      const tree = r.toJSON();
+      const root = r.root;
+
+      expect(tree.props.className).toContain('error');
+      expect(root.findByProps({ currentColor: 'caution' }));
+    });
+
+    it('can have no error state', () => {
+      const r = renderer.create((
+        <CustomFieldInputText error={false} />
+      ));
+      const tree = r.toJSON();
+      const root = r.root;
+
+      expect(tree.props.className).not.toContain('error');
+      expect(root.findByProps({ className: 'input-container' }).children.length).toEqual(1);
     });
   });
 

--- a/src/components/custom-field-input-text/custom-field-input-text.test.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.test.jsx
@@ -118,6 +118,26 @@ describe('CustomFieldInputText', () => {
     });
   });
 
+  describe('required API', () => {
+    it('can have a required indicator', () => {
+      const r = renderer.create((
+        <CustomFieldInputText required={true} />
+      ));
+      const root = r.root;
+
+      expect(root.findByProps({ className: 'optional' }));
+    });
+
+    it('can have no required indicator', () => {
+      const r = renderer.create((
+        <CustomFieldInputText />
+      ));
+      const root = r.root;
+
+      expect(root.findByProps({ className: 'input-container' }).children.length).toEqual(1);
+    });
+  });
+
   describe('id API', () => {
     it('sets the id attribute', () => {
       const tree = renderer.create((

--- a/styleguide/components/styleguide/styleguide.css
+++ b/styleguide/components/styleguide/styleguide.css
@@ -23,6 +23,5 @@
   top: 65px;
   left: 0;
   bottom: 0;
-  width: 200px;
   overflow: auto;
 }

--- a/styleguide/components/styleguide/styleguide.css
+++ b/styleguide/components/styleguide/styleguide.css
@@ -23,5 +23,6 @@
   top: 65px;
   left: 0;
   bottom: 0;
+  width: 200px;
   overflow: auto;
 }


### PR DESCRIPTION
- Tweak the sidebar to use a dynamic width to account for long component names

Type of work: component

Deployment URL: https://mavenlink.github.io/design-system/custom-field-input-text

(Optional for outside contributions) Tracked work in Mavenlink: https://www.pivotaltracker.com/story/show/169509661

## Motivation
New "custom field" inputs of various types are needed for 3rd party custom forms as part of the MBridge work.

## Acceptance Criteria

1. The component is in the MDS site
2. It looks like an MDS input
3. It has a label
4. It can be disabled
5. It has placeholder text
6. It has an optional "unique value" constraint
7. It follows the Zeplin design

## Change log entry
