### PR TITLE
Contributing tips

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,3 +33,7 @@ In short, when you submit code changes, your submissions are understood to be un
 
 ## Reporting Bugs
 We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/mavenlink/design-system/issues/new). Please provide details, background, and sample code if possible.
+
+## Tips
+
+- `yarn test -o` runs only changed test files


### PR DESCRIPTION
Type of work: other

Deployment URL: https://mavenlink.github.io/design-system/tips

(Optional for outside contributions) Tracked work in Mavenlink:

## Motivation

<!-- This section is reserved for reasoning and historical context on the proposed change set -->
I found this useful. I think it might be nice to have a sections for useful bits of information for others. Maybe it does not work in the long run but we can remove it then.
<!-- END MOTIVIATION-->

## Acceptance Criteria

<!-- This section is reserved for documenting the qualifiers for accepting the PR (besides a green build) -->
Since it is a doc changeset then a green CI workflow is enough.
<!-- END ACCEPTANCE CRITERIA -->

## Change log entry

<!-- This section is reserved for change log entry. We need to copy this to the CHANGELOG.md file before merging -->
<!-- END CHANGE LOG ENTRY -->
