### PR TITLE
Add "autoFocus" and "ref" Attributes To Input Component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,9 @@ module.exports = {
       ignorePackages: true,
     }],
   },
+  env: {
+    browser: true,
+  },
   overrides: [{
     files: [
       '**/*.test.js',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,9 +6,6 @@ module.exports = {
       ignorePackages: true,
     }],
   },
-  env: {
-    browser: true,
-  },
   overrides: [{
     files: [
       '**/*.test.js',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mavenlink/design-system",
-  "version": "0.11.0",
+  "version": "0.11.0-autofocus",
   "description": "Mavenlink React Components",
   "main": "src/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mavenlink/design-system",
-  "version": "0.11.0-autofocus",
+  "version": "0.12.0",
   "description": "Mavenlink React Components",
   "main": "src/index.js",
   "files": [

--- a/src/components/input/input.jsx
+++ b/src/components/input/input.jsx
@@ -22,6 +22,7 @@ export default function Input(props) {
       </label>
       <div className={props.cssContainer}>
         <input
+          autoFocus={props.autoFocus} // eslint-disable-line jsx-a11y/no-autofocus
           className={getClassName(props.className, props.invalid)}
           disabled={props.disabled}
           id={props.id}
@@ -46,6 +47,7 @@ export default function Input(props) {
 }
 
 Input.propTypes = {
+  autoFocus: PropTypes.bool,
   className: PropTypes.string,
   cssContainer: PropTypes.string,
   cssLabel: PropTypes.string,
@@ -73,6 +75,7 @@ Input.propTypes = {
 };
 
 Input.defaultProps = {
+  autoFocus: undefined,
   className: undefined,
   cssContainer: styles.container,
   cssLabel: undefined,

--- a/src/components/input/input.jsx
+++ b/src/components/input/input.jsx
@@ -34,6 +34,7 @@ export default function Input(props) {
           onKeyDown={props.onKeyDown}
           placeholder={props.placeholder}
           readOnly={props.readOnly}
+          ref={props.inputRef}
           required={props.required}
           type={props.type}
           value={props.value}
@@ -50,6 +51,10 @@ Input.propTypes = {
   cssLabel: PropTypes.string,
   disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(HTMLInputElement) }),
+  ]),
   invalid: PropTypes.bool,
   label: PropTypes.string.isRequired,
   maxLength: PropTypes.number,
@@ -76,6 +81,7 @@ Input.defaultProps = {
   cssLabel: undefined,
   disabled: undefined,
   invalid: false,
+  inputRef: undefined,
   maxLength: undefined,
   name: undefined,
   onBlur: undefined,

--- a/src/components/input/input.jsx
+++ b/src/components/input/input.jsx
@@ -51,10 +51,7 @@ Input.propTypes = {
   cssLabel: PropTypes.string,
   disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
-  inputRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(HTMLInputElement) }),
-  ]),
+  inputRef: PropTypes.shape({ current: PropTypes.any }),
   invalid: PropTypes.bool,
   label: PropTypes.string.isRequired,
   maxLength: PropTypes.number,

--- a/src/components/input/input.test.jsx
+++ b/src/components/input/input.test.jsx
@@ -313,4 +313,17 @@ describe('Input', () => {
       expect(tree.find('input').props().value).toEqual(inputRef.current.value);
     });
   });
+
+  describe('autoFocus API', () => {
+    it('sets the autoFocus attribute', () => {
+      const tree = renderer.create((
+        <Input
+          id="foo"
+          label="I am a label for accessibility"
+          autoFocus
+        />
+      )).root;
+      expect(tree.findByType('input').props.autoFocus).toEqual(true);
+    });
+  });
 });

--- a/src/components/input/input.test.jsx
+++ b/src/components/input/input.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { mount } from 'enzyme';
 import renderer from 'react-test-renderer';
 import Input from './input.jsx';
 
@@ -294,6 +295,22 @@ describe('Input', () => {
         />
       )).root;
       expect(tree.findByType('input').props.value).toEqual('test-value');
+    });
+  });
+
+  describe('ref API', () => {
+    it('is set to the inputRef property', () => {
+      const inputRef = React.createRef();
+      const tree = mount(
+        <Input
+          id="foo"
+          label="I am a label for accessibility"
+          inputRef={inputRef}
+          onChange={() => {}}
+          value="test-value"
+        />,
+      );
+      expect(tree.find('input').props().value).toEqual(inputRef.current.value);
     });
   });
 });


### PR DESCRIPTION
Type of work: component / accessibility

Deployment URL: https://mavenlink.github.io/design-system/ds-add-ref-attribute-to-input-component

## Motivation

Adding the `ref` attribute, in order to enable auto-focusing on the input element of the Input component.

## Acceptance Criteria

## Change log entry

