### PR TITLE
[webinf-oops-forgot-all-the-read-only] Readonly attribute was not included on Number custom field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
   <summary>
     Changes that have landed in master but are not yet released.
     Click to see more.
+    
+    - Add readOnly prop to CustomFieldInputCurrency and CustomFieldInputNumber
   </summary>
 </details>
 

--- a/src/components/custom-field-input-currency/custom-field-input-currency.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.jsx
@@ -93,6 +93,7 @@ export default function CustomFieldInputCurrency(props) {
     label: props.label,
     name: props.name,
     placeholder: props.placeholder,
+    readOnly: props.readOnly,
     required: props.required,
   };
 
@@ -133,6 +134,7 @@ CustomFieldInputCurrency.propTypes = {
   name: PropTypes.string,
   // onChange: Do not expose an onChange handler. See commit for details.
   placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
   required: PropTypes.bool,
   value: PropTypes.number,
 };
@@ -145,6 +147,7 @@ CustomFieldInputCurrency.defaultProps = {
   helpText: undefined,
   name: undefined,
   placeholder: undefined,
+  readOnly: false,
   required: false,
   value: undefined,
 };

--- a/src/components/custom-field-input-currency/custom-field-input-currency.test.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.test.jsx
@@ -86,6 +86,18 @@ describe('CustomFieldInputCurrency', () => {
     });
   });
 
+  describe('readOnly API', () => {
+    it('respects the readOnly prop', () => {
+      const { getByLabelText } = renderComponent({ readOnly: true });
+      expect(getByLabelText('currency')).toHaveAttribute('readOnly', '');
+    });
+
+    it('is false by default', () => {
+      const { getByLabelText } = renderComponent();
+      expect(getByLabelText('currency')).not.toHaveAttribute('readOnly', '');
+    });
+  });
+
   describe('input validation', () => {
     it('does not trigger error state for valid value', () => {
       const { getByTestId, getByLabelText } = renderComponent();

--- a/src/components/custom-field-input-number/custom-field-input-number.jsx
+++ b/src/components/custom-field-input-number/custom-field-input-number.jsx
@@ -49,6 +49,7 @@ export default function CustomFieldInputNumber(props) {
       onBlur={props.onBlur}
       onKeyUp={handleOnKeyUp}
       placeholder={props.placeholder}
+      readOnly={props.readOnly}
       required={props.required}
       step={props.step}
       type="number"
@@ -67,6 +68,7 @@ CustomFieldInputNumber.propTypes = {
   onBlur: PropTypes.func,
   // onChange: Do not expose the onChange handler. See commit for details.
   placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
   required: PropTypes.bool,
   step: PropTypes.number,
   value: PropTypes.oneOfType([
@@ -82,6 +84,7 @@ CustomFieldInputNumber.defaultProps = {
   name: undefined,
   onBlur: () => {},
   placeholder: undefined,
+  readOnly: false,
   required: false,
   step: 1,
   value: '',

--- a/src/components/custom-field-input-number/custom-field-input-number.test.jsx
+++ b/src/components/custom-field-input-number/custom-field-input-number.test.jsx
@@ -119,6 +119,18 @@ describe('CustomFieldInputNumber', () => {
     });
   });
 
+  describe('readOnly API', () => {
+    it('respects the readOnly prop', () => {
+      const { getByLabelText } = render(<TestComponent readOnly />);
+      expect(getByLabelText('Test label')).toHaveAttribute('readOnly', '');
+    });
+
+    it('is false by default', () => {
+      const { getByLabelText } = render(<TestComponent />);
+      expect(getByLabelText('Test label')).not.toHaveAttribute('readOnly', '');
+    });
+  });
+
   describe('step API', () => {
     it('respects a provided step', () => {
       const { getByLabelText } = render(<TestComponent label="foo" step={12} />);


### PR DESCRIPTION
## Motivation

* I forgot to put the readonly prop on all of the custom fields, not just the CustomFieldText...

## Acceptance Criteria

* All of the custom fields can be read only

## Change log entry

<!-- This section is reserved for change log entry. We need to copy this to the CHANGELOG.md file before merging -->
<!-- END CHANGE LOG ENTRY -->

<details>
<summary>PR upkeep checklist</summary>
<br />

- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-oops-forgot-all-the-read-only
- [x] (Optional) Pivotal tracker URL: https://www.pivotaltracker.com/story/show/171681678
- [x] (When ready for review) Reviewer(s)

</details>
