### PR TITLE
[webinf-input-class-name-171943369] Add input class name to custom fields

### DIFF
--- a/src/components/custom-field-input-currency/custom-field-input-currency.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.jsx
@@ -90,6 +90,7 @@ export default function CustomFieldInputCurrency(props) {
     className: getRootClassName(props.className, props.error, props.disabled),
     disabled: props.disabled,
     id: props.id,
+    inputClassName: props.inputClassName,
     label: props.label,
     name: props.name,
     placeholder: props.placeholder,
@@ -130,6 +131,7 @@ CustomFieldInputCurrency.propTypes = {
   error: PropTypes.bool,
   helpText: PropTypes.string,
   id: PropTypes.string.isRequired,
+  inputClassName: PropTypes.string,
   label: PropTypes.string.isRequired,
   name: PropTypes.string,
   // onChange: Do not expose an onChange handler. See commit for details.
@@ -145,6 +147,7 @@ CustomFieldInputCurrency.defaultProps = {
   disabled: false,
   error: false,
   helpText: undefined,
+  inputClassName: styles.input,
   name: undefined,
   placeholder: undefined,
   readOnly: false,

--- a/src/components/custom-field-input-currency/custom-field-input-currency.test.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.test.jsx
@@ -31,7 +31,7 @@ describe('CustomFieldInputCurrency', () => {
   describe('prop-forward API', () => {
     it('forwards all props accepted by CustomFieldInputText on Object keys', () => {
       const excludedNumberProps = ['inputRef', 'max', 'min', 'onKeyUp', 'onKeyDown', 'step', 'onBlur', 'onFocus',
-        'type', 'readOnly', 'icon', 'onChange'];
+        'type', 'readOnly', 'icon', 'onChange', 'inputClassName'];
       const currencyProps = Object.keys(CustomFieldInputCurrency.propTypes);
       const inputTextProps = Object.keys(CustomFieldInputText.propTypes).filter(p => !excludedNumberProps.includes(p));
 

--- a/src/components/custom-field-input-currency/custom-field-input-currency.test.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.test.jsx
@@ -86,6 +86,13 @@ describe('CustomFieldInputCurrency', () => {
     });
   });
 
+  describe('inputClassName API', () => {
+    it('prioritizes inputClassName prop', () => {
+      const { getByLabelText } = renderComponent({ inputClassName: 'prioritize-me' });
+      expect(getByLabelText('currency')).toHaveClass('prioritize-me');
+    });
+  });
+
   describe('readOnly API', () => {
     it('respects the readOnly prop', () => {
       const { getByLabelText } = renderComponent({ readOnly: true });

--- a/src/components/custom-field-input-date/custom-field-input-date.jsx
+++ b/src/components/custom-field-input-date/custom-field-input-date.jsx
@@ -4,6 +4,7 @@ import calendarSvg from '../../svgs/icon-calendar-fill.svg';
 import Icon from '../icon/icon.jsx';
 import CustomFieldInputText from '../custom-field-input-text/custom-field-input-text.jsx';
 import { convertToFormat, validDate } from './format/format-date.js';
+import styles from '../custom-field-input-text/custom-field-input-text.css';
 
 const isValidInput = (value) => {
   if (value === '' || value === undefined) {
@@ -72,6 +73,7 @@ export default function CustomFieldInputDate(props) {
     disabled: props.disabled,
     icon: <Icon name={calendarSvg.id} title={props.label} stroke="gray" />,
     label: props.label,
+    inputClassName: props.inputClassName,
     inputRef,
     readOnly: true,
     required: props.required,
@@ -110,6 +112,7 @@ CustomFieldInputDate.propTypes = {
   error: PropTypes.bool,
   helpText: PropTypes.string,
   id: PropTypes.string.isRequired,
+  inputClassName: PropTypes.string,
   label: PropTypes.string.isRequired,
   min: PropTypes.string,
   max: PropTypes.string,
@@ -123,6 +126,7 @@ CustomFieldInputDate.defaultProps = {
   disabled: false,
   error: false,
   helpText: '',
+  inputClassName: styles.input,
   min: undefined,
   max: undefined,
   onChange: () => {},

--- a/src/components/custom-field-input-date/custom-field-input-date.test.jsx
+++ b/src/components/custom-field-input-date/custom-field-input-date.test.jsx
@@ -25,6 +25,13 @@ describe('src/components/custom-field-input-date/custom-field-input-date', () =>
     });
   });
 
+  describe('inputClassName API', () => {
+    it('prioritizes inputClassName prop', () => {
+      const { getByLabelText } = renderComponent({ inputClassName: 'prioritize-me' });
+      expect(getByLabelText('Field Date')).toHaveClass('prioritize-me');
+    });
+  });
+
   describe('value API', () => {
     it('accepts a string in format YYYY-MM-DD', () => {
       const { getByLabelText } = renderComponent({ value: '2016-07-18' });

--- a/src/components/custom-field-input-number/custom-field-input-number.jsx
+++ b/src/components/custom-field-input-number/custom-field-input-number.jsx
@@ -41,6 +41,7 @@ export default function CustomFieldInputNumber(props) {
       disabled={props.disabled}
       error={invalid}
       id={props.id}
+      inputClassName={props.inputClassName}
       inputRef={inputRef}
       label={props.label}
       max={apiLimits.max}
@@ -62,6 +63,7 @@ CustomFieldInputNumber.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
+  inputClassName: PropTypes.string,
   inputRef: PropTypes.shape({ current: PropTypes.any }),
   label: PropTypes.string.isRequired,
   name: PropTypes.string,
@@ -80,6 +82,7 @@ CustomFieldInputNumber.propTypes = {
 CustomFieldInputNumber.defaultProps = {
   className: styles['custom-field-input-text'],
   disabled: false,
+  inputClassName: styles.input,
   inputRef: undefined,
   name: undefined,
   onBlur: () => {},

--- a/src/components/custom-field-input-number/custom-field-input-number.test.jsx
+++ b/src/components/custom-field-input-number/custom-field-input-number.test.jsx
@@ -20,6 +20,13 @@ describe('CustomFieldInputNumber', () => {
     });
   });
 
+  describe('inputClassName API', () => {
+    it('prioritizes inputClassName prop', () => {
+      const { getByLabelText } = render(<TestComponent inputClassName="prioritize-me" />);
+      expect(getByLabelText('Test label')).toHaveClass('prioritize-me');
+    });
+  });
+
   describe('disabled API', () => {
     it('can be disabled', () => {
       const { container } = render(<TestComponent disabled />);

--- a/src/components/custom-field-input-text/custom-field-input-text.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.jsx
@@ -71,7 +71,7 @@ export default function CustomFieldInputText(props) {
       <div className={styles['input-container']}>
         <input
           defaultValue={props.value}
-          className={styles.input}
+          className={props.inputClassName}
           disabled={props.disabled}
           id={props.id}
           max={props.max}
@@ -106,6 +106,7 @@ CustomFieldInputText.propTypes = {
   helpText: PropTypes.string,
   icon: PropTypes.node,
   id: PropTypes.string.isRequired,
+  inputClassName: PropTypes.string,
   inputRef: PropTypes.shape({ current: PropTypes.any }),
   label: PropTypes.string.isRequired,
   max: PropTypes.oneOfType([
@@ -142,6 +143,7 @@ CustomFieldInputText.defaultProps = {
   error: false,
   helpText: undefined,
   icon: undefined,
+  inputClassName: styles.input,
   inputRef: undefined,
   max: undefined,
   min: undefined,

--- a/src/components/custom-field-input-text/custom-field-input-text.test.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.test.jsx
@@ -21,6 +21,13 @@ describe('CustomFieldInputText', () => {
     });
   });
 
+  describe('inputClassName API', () => {
+    it('prioritizes inputClassName prop', () => {
+      const { getByLabelText } = render(<TestComponent inputClassName="prioritize-me" />);
+      expect(getByLabelText('Test label')).toHaveClass('prioritize-me');
+    });
+  });
+
   describe('disabled API', () => {
     it('can be disabled', () => {
       const { container } = render(<TestComponent disabled />);


### PR DESCRIPTION
## Motivation

* In an effort to present external MDS components in bigmaven, it was deemed requisite to add a customizable class name for the input element of each custom field

## Acceptance Criteria

* All custom fields prioritize the class name for their input element provided in props over the default one

## Change log entry

* Add input class name to each custom field

<details>
<summary>PR upkeep checklist</summary>
<br />

- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-input-class-name-171943369
- [ x (Optional) [Pivotal tracker URL](https://www.pivotaltracker.com/story/show/171943369)
- [x] (When ready for review) Reviewer(s)

</details>
