### PR TITLE
Modify the CustomFieldInputCurrency value API to only accept subunits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
     Changes that have landed in master but are not yet released.
     Click to see more.
   </summary>
+
+  - Modify the CustomFieldInputCurrency value API to only accept subunit values of the currency
 </details>
 
 ## 0.18.0 (April 8, 2020)

--- a/src/components/custom-field-input-currency/custom-field-input-currency.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.jsx
@@ -27,35 +27,36 @@ function getLocale() {
   return 'en-IN';
 }
 
-function initialInputValid(inputValue, currencyCode) {
-  const maximumFractionDigits = currencyMetaData[currencyCode].maximumFractionDigits;
-
+function initialInputValid(inputValue) {
   if (!inputValue) {
     return true;
   }
 
-  const splitInputValue = inputValue.toString().split('.');
-  if (splitInputValue.length === 1) {
+  if (inputValue.toString().split('.').length === 1) {
     return true;
   }
 
-  return splitInputValue[1].length <= maximumFractionDigits;
+  return false;
 }
 
-function formatValue(inputValue, currencyCode) {
-  if (!inputValue) {
-    return '';
-  }
+function subunitToUnit(subunitValue, currencyCode) {
+  if (!subunitValue) return '';
+
+  return subunitValue / (10 ** currencyMetaData[currencyCode].maximumFractionDigits);
+}
+
+function formatValue(unitValue, currencyCode) {
+  if (!unitValue) return '';
 
   return new Intl.NumberFormat(getLocale(), {
     style: 'currency',
     currency: currencyCode,
     maximumFractionDigits: currencyMetaData[currencyCode].maximumFractionDigits,
-  }).format(inputValue);
+  }).format(unitValue);
 }
 
 export default function CustomFieldInputCurrency(props) {
-  const [input, setInput] = useState(props.value);
+  const [input, setInput] = useState(subunitToUnit(props.value, props.currencyCode));
   const [isEditing, setIsEditing] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
   const numberRef = useRef(null);
@@ -75,7 +76,7 @@ export default function CustomFieldInputCurrency(props) {
   }
 
   useEffect(() => {
-    if (!numberRef.current && !initialInputValid(props.value, props.currencyCode)) {
+    if (!numberRef.current && !initialInputValid(props.value)) {
       setIsEditing(true);
     }
   }, []);

--- a/src/components/custom-field-input-currency/custom-field-input-currency.md
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.md
@@ -15,7 +15,7 @@ within itself.
   label="Iraqi Dinar"
   currencyCode="IQD"
   id="iraqi-dinar"
-  value={182.211}
+  value={182211}
 />
 
 <CustomFieldInputCurrency
@@ -47,7 +47,7 @@ presented to it, responding with a specific message for the context of that spec
 <CustomFieldInputCurrency
   id="test-id-3"
   name="test-name-3"
-  value={1.12}
+  value={112}
   currencyCode="XAF"
   label="Internal Error State"
 />
@@ -56,7 +56,7 @@ presented to it, responding with a specific message for the context of that spec
   label="External Error State"
   id="test-id-4"
   name="test-name-4"
-  value={3.50}
+  value={350}
   currencyCode="USD"
   error
   helpText="What do you want from us monster!?"

--- a/src/components/custom-field-input-currency/custom-field-input-currency.test.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.test.jsx
@@ -20,7 +20,7 @@ describe('CustomFieldInputCurrency', () => {
   });
 
   it('sets the correct step according to the provided currency code', () => {
-    const { getByLabelText } = renderComponent({ currencyCode: 'IQD', value: 10.111 });
+    const { getByLabelText } = renderComponent({ currencyCode: 'IQD', value: 10111 });
 
     // NOTE: This space is character code 160, non-breaking space. It did break my brain though
     expect(getByLabelText('currency')).toHaveValue('IQD 10.111');
@@ -52,7 +52,7 @@ describe('CustomFieldInputCurrency', () => {
 
     it('presents contextual error state', () => {
       const helpText = 'What do you want from us monster!?';
-      const { getByTestId } = renderComponent({ value: 3.50, helpText, error: true });
+      const { getByTestId } = renderComponent({ value: 350, helpText, error: true });
       const presentedHelpText = () => getByTestId('custom-field-input').querySelector('.help').innerHTML;
 
       expect(getByTestId('custom-field-input')).toHaveClass('error');


### PR DESCRIPTION
## Motivation

This allows our component to align with the Mavenlink API. We normally are dealing with money through subunits. Let us also keep the component with similar behavior to simplify reasoning (and thus simplify code). This is a major change but thankfully we are in beta still.

For example: if we want to represent $13.37 then we will pass in 1337 as a value and a currency code of USD. Our component already knows how to manipulate the cents because we are using some ISO standard and we are pulling that specification into our codebase.

## Acceptance Criteria

We can use the component by passing in cents and getting dollars (with decimals) -- depending on the currency code. 

<details>
<summary>PR upkeep checklist</summary>
<br />

- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/currency-subunit-to-unit
- [x] (Optional) Pivotal tracker URL: https://www.pivotaltracker.com/story/show/172343217
- [x] (When ready for review) Reviewer(s)

</details>
