### PR TITLE
[webinf-touissant-l-ouverture-171681683] User sees a (readonly) date field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## [Unreleased]
 <details>
   <summary>
-    Changes that have landed in master but are not yet released.
-    Click to see more.
+    * Replace old calendar icon with new one provided by Design.
   </summary>
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## [Unreleased]
 <details>
   <summary>
-    * Replace old calendar icon with new one provided by Design.
+    Changes that have landed in master but are not yet released.
   </summary>
-
+  
+  * Replace old calendar icon with new one provided by Design
 </details>
 
 ## 0.19.0 (April 20, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## [Unreleased]
 <details>
   <summary>
-	Changes that have landed in master but are not yet released.
-	Click to see more.
+    Changes that have landed in master but are not yet released.
+    Click to see more.
   </summary>
 
   * Replace old calendar icon with new one provided by Design

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## [Unreleased]
 <details>
   <summary>
-    Changes that have landed in master but are not yet released.
+	Changes that have landed in master but are not yet released.
+	Click to see more.
   </summary>
-  
+
   * Replace old calendar icon with new one provided by Design
 </details>
 

--- a/src/components/custom-field-input-date/__snapshots__/custom-field-input-date.test.jsx.snap
+++ b/src/components/custom-field-input-date/__snapshots__/custom-field-input-date.test.jsx.snap
@@ -36,7 +36,7 @@ exports[`src/components/custom-field-input-date/custom-field-input-date has defa
       className="input-icon-container"
     >
       <svg
-        className="icon-base size-medium fill-none stroke-gray color-transparent"
+        className="icon-base size-medium fill-gray stroke-gray color-transparent"
         role="img"
       >
         <title>

--- a/src/components/custom-field-input-date/custom-field-input-date.jsx
+++ b/src/components/custom-field-input-date/custom-field-input-date.jsx
@@ -70,7 +70,7 @@ export default function CustomFieldInputDate(props) {
   const sharedProps = {
     className: props.className,
     disabled: props.disabled,
-    icon: <Icon name={calendarSvg.id} title={props.label} stroke="gray" />,
+    icon: <Icon name={calendarSvg.id} title={props.label} stroke="gray" fill="gray" />,
     label: props.label,
     inputRef,
     readOnly: true,

--- a/src/components/custom-field-input-text/custom-field-input-text.css
+++ b/src/components/custom-field-input-text/custom-field-input-text.css
@@ -60,6 +60,7 @@
   position: absolute;
   margin-left: -28px;
   margin-top: var(--spacing-small);
+  pointer-events: none;
   width: 20px;
 }
 

--- a/src/svgs/icon-calendar-fill.svg
+++ b/src/svgs/icon-calendar-fill.svg
@@ -1,36 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-     viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
-  <g id="_x31_6px_border" display="none">
-    <rect x="0" display="inline" opacity="0.2" fill="#666666" width="16" height="16"/>
-  </g>
-  <g id="live_icon" display="none">
-		<rect x="3.5" y="3.4" display="inline" fill="none" stroke="#666666" stroke-linejoin="round" stroke-miterlimit="10" width="10.1" height="12"/>
-
-    <line display="inline" fill="none" stroke="#666666" stroke-linejoin="round" stroke-miterlimit="10" x1="3.5" y1="6.6" x2="13.6" y2="6.6"/>
-
-    <line display="inline" fill="none" stroke="#666666" stroke-linejoin="round" stroke-miterlimit="10" x1="3.5" y1="9.6" x2="13.6" y2="9.6"/>
-
-    <line display="inline" fill="none" stroke="#666666" stroke-width="0.9818" stroke-linejoin="round" stroke-miterlimit="10" x1="6.4" y1="6.1" x2="6.4" y2="15.8"/>
-
-    <line display="inline" fill="none" stroke="#666666" stroke-width="0.9818" stroke-linejoin="round" stroke-miterlimit="10" x1="10.4" y1="6.1" x2="10.4" y2="15.8"/>
-
-    <line display="inline" fill="none" stroke="#666666" stroke-linejoin="round" stroke-miterlimit="10" x1="3.5" y1="12.6" x2="13.6" y2="12.6"/>
-
-    <line display="inline" fill="none" stroke="#666666" stroke-width="0.9818" stroke-linejoin="round" stroke-miterlimit="10" x1="5.1" y1="2.5" x2="7" y2="2.5"/>
-
-    <line display="inline" fill="none" stroke="#666666" stroke-width="0.9818" stroke-linejoin="round" stroke-miterlimit="10" x1="10.2" y1="2.5" x2="12" y2="2.5"/>
-  </g>
-  <g id="booleaned">
-    <g>
-      <path stroke-width="0.9" fill="#666666" d="M12.5,1.9h-10C2.2,1.9,2,2.1,2,2.4v11.9c0,0.2,0.2,0.5,0.5,0.5h2.6H6h3h0.9h2.5c0.2,0,0.5-0.2,0.5-0.5V2.4
-        C12.9,2.1,12.7,1.9,12.5,1.9z M5.1,13.9H2.9v-2.1h2.2V13.9z M5.1,11.1H2.9V8.8h2.2V11.1z M5.1,8H2.9V5.9h2.2V8z M9,13.9H6v-2.1h3
-        V13.9z M9,11.1H6V8.8h3V11.1z M9,8H6V5.9h3V8z M12,13.9H9.9v-2.1H12V13.9z M12,11.1H9.9V8.8H12V11.1z M12,8H9.9V5.9H12V8z M12,5.1
-        H2.9V2.8H12V5.1z"/>
-      <rect stroke-width="0.9" x="4.1" y="1" fill="#666666" width="1.9" height="0.9"/>
-      <rect stroke-width="0.9" x="9.2" y="1" fill="#666666" width="1.8" height="0.9"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="32px" height="33px" viewBox="0 0 32 33" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <!-- Generator: Sketch 64 (93537) - https://sketch.com -->
+  <title>Calendar Icon</title>
+  <desc>Created with Sketch.</desc>
+  <g id="Calendar-Icon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="Icons/Controls&amp;Misc/calendar" transform="translate(3.000000, 3.000000)" fill="#9D9D9D" fill-rule="nonzero">
+      <path d="M10.125,1.6875 L10.125,3.375 L15.1875,3.375 L15.1875,1.6875 L18.5625,1.6875 L18.5625,3.375 L20.25,3.375 C21.1819805,3.375 21.9375,4.13051948 21.9375,5.0625 L21.9375,23.625 C21.9375,24.5569805 21.1819805,25.3125 20.25,25.3125 L5.0625,25.3125 C4.13051948,25.3125 3.375,24.5569805 3.375,23.625 L3.375,5.0625 C3.375,4.13051948 4.13051948,3.375 5.0625,3.375 L6.75,3.375 L6.75,1.6875 L10.125,1.6875 Z M8.437,20.2495 L5.062,20.2495 L5.0625,23.625 L8.437,23.6245 L8.437,20.2495 Z M20.25,20.2495 L16.875,20.2495 L16.875,23.6245 L20.25,23.625 L20.25,20.2495 Z M15.187,20.2495 L10.125,20.2495 L10.125,23.6245 L15.187,23.6245 L15.187,20.2495 Z M8.437,15.1875 L5.062,15.1875 L5.062,18.5625 L8.437,18.5625 L8.437,15.1875 Z M20.25,15.1875 L16.875,15.1875 L16.875,18.5625 L20.25,18.5625 L20.25,15.1875 Z M15.187,15.1875 L10.125,15.1875 L10.125,18.5625 L15.187,18.5625 L15.187,15.1875 Z M8.437,10.1245 L5.062,10.1245 L5.062,13.4995 L8.437,13.4995 L8.437,10.1245 Z M20.25,10.1245 L16.875,10.1245 L16.875,13.4995 L20.25,13.4995 L20.25,10.1245 Z M15.187,10.1245 L10.125,10.1245 L10.125,13.4995 L15.187,13.4995 L15.187,10.1245 Z M20.25,5.0625 L5.0625,5.0625 L5.062,8.4375 L20.25,8.4375 L20.25,5.0625 Z" id="Combined-Shape" />
     </g>
   </g>
 </svg>

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -105,4 +105,5 @@ module.exports = {
   title: 'Mavenlink Design System',
   usageMode: 'expand',
   webpackConfig,
+  serverPort: 6061,
 };

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -105,5 +105,4 @@ module.exports = {
   title: 'Mavenlink Design System',
   usageMode: 'expand',
   webpackConfig,
-  serverPort: 6061,
 };


### PR DESCRIPTION
## Motivation (or lack thereof)

* An improved calendar icon was provided to us from the design team, and we wanted to include that instead of the older one we have

## Acceptance Criteria

* The new calendar icon is included and styled per Design's request and prescription

## Change log entry

* Replace old calendar icon with new one provided by Design.


- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-touissant-l-ouverture-171681683
- [x] (Optional) Pivotal tracker URL: https://www.pivotaltracker.com/story/show/171681683
- [x] (Mandatory) Song for branch: https://www.youtube.com/watch?v=JlqBcXh231g
- [x] (When ready for review) Reviewer(s)

</details>
