### PR TITLE
Ensure readonly and disabled currency component does not enter edit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
     Click to see more.
   </summary>
 
+  - Patch: Fix read-only currency component: do not enter edit mode on focus
+  - Patch: Fix disabled currency component: do not enter edit mode on focus
 </details>
 
 ## 0.19.0 (April 20, 2020)

--- a/src/components/custom-field-input-currency/custom-field-input-currency.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.jsx
@@ -71,6 +71,8 @@ export default function CustomFieldInputCurrency(props) {
   }
 
   function handleOnFocus() {
+    if (props.disabled || props.readOnly) return;
+
     setIsEditing(true);
     setIsFocused(true);
   }

--- a/src/components/custom-field-input-currency/custom-field-input-currency.test.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.test.jsx
@@ -40,16 +40,6 @@ describe('CustomFieldInputCurrency', () => {
       });
     });
 
-    it('respects the disabled prop', () => {
-      const { getByLabelText } = renderComponent({ disabled: true });
-      expect(getByLabelText('currency')).toBeDisabled();
-    });
-
-    it('respects the enabled prop', () => {
-      const { getByLabelText } = renderComponent({ disabled: false });
-      expect(getByLabelText('currency')).not.toBeDisabled();
-    });
-
     it('presents contextual error state', () => {
       const helpText = 'What do you want from us monster!?';
       const { getByTestId } = renderComponent({ value: 350, helpText, error: true });
@@ -86,10 +76,34 @@ describe('CustomFieldInputCurrency', () => {
     });
   });
 
+  describe('disabled API', () => {
+    it('respects the disabled prop', () => {
+      const { getByLabelText } = renderComponent({ disabled: true });
+      expect(getByLabelText('currency')).toBeDisabled();
+    });
+
+    it('does not enter edit mode on focus', () => {
+      const { getByLabelText } = renderComponent({ disabled: true });
+      fireEvent.focus(getByLabelText('currency'));
+      expect(getByLabelText('currency')).toHaveAttribute('type', 'text');
+    });
+
+    it('respects the enabled prop', () => {
+      const { getByLabelText } = renderComponent({ disabled: false });
+      expect(getByLabelText('currency')).not.toBeDisabled();
+    });
+  });
+
   describe('readOnly API', () => {
     it('respects the readOnly prop', () => {
       const { getByLabelText } = renderComponent({ readOnly: true });
       expect(getByLabelText('currency')).toHaveAttribute('readOnly', '');
+    });
+
+    it('does not enter edit mode on focus', () => {
+      const { getByLabelText } = renderComponent({ readOnly: true });
+      fireEvent.focus(getByLabelText('currency'));
+      expect(getByLabelText('currency')).toHaveAttribute('type', 'text');
     });
 
     it('is false by default', () => {


### PR DESCRIPTION
## Motivation

<!-- This section is reserved for reasoning and historical context on the proposed change set -->
We want a well-behaved read-only and disabled currency components.
<!-- END MOTIVIATION-->

## Acceptance Criteria

<!-- This section is reserved for documenting the qualifiers for accepting the PR (besides a green build) -->
- The read-only mode of a currency component does not change when focusing the component
- The disabled mode of a currency component does not change when focusing the component
<!-- END ACCEPTANCE CRITERIA -->

## Change log entry

<!-- This section is reserved for change log entry. We need to copy this to the CHANGELOG.md file before merging -->
* Fix read-only currency component: do not enter edit mode on focus
* Fix disabled currency component: do not enter edit mode on focus
<!-- END CHANGE LOG ENTRY -->

<details>
<summary>PR upkeep checklist</summary>
<br />

- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/readonly-currency
- [x] (Optional) Pivotal tracker URL: https://www.pivotaltracker.com/story/show/172570681
- [x] (When ready for review) Reviewer(s)

</details>
