### PR TITLE
[webinf-oops-i-broke-the-error-again] Fix documentation issue

### DIFF
--- a/src/components/custom-field-input-currency/custom-field-input-currency.md
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.md
@@ -47,7 +47,7 @@ presented to it, responding with a specific message for the context of that spec
 <CustomFieldInputCurrency
   id="test-id-3"
   name="test-name-3"
-  value={112}
+  value={112.5}
   currencyCode="XAF"
   label="Internal Error State"
 />


### PR DESCRIPTION
Co-authored-by: Juan-Carlos Medina <juanca@mavenlink.com>

## Motivation

Fix the documentation of the currency component to properly display internal error state.

## Acceptance Criteria

Internal error state for currency component is properly displayed.

## Change log entry

- Fix documentation for currency component to show internal error state

<details>
<summary>PR upkeep checklist</summary>
<br />

- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-oops-i-broke-the-error-again
- [x] (Optional) [Pivotal tracker Story](https://www.pivotaltracker.com/story/show/171943378)
- [x] (Mandatory) ["...Baby One More Time" by August Burns Red](https://www.youtube.com/watch?v=VL5sEhSuuFE) 
- [x] (When ready for review) Reviewer(s)

</details>
