### PR TITLE
[webinf-single-choice-early-in-the-morning-172540830] CustomFieldInputSingleChoice component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
     Click to see more.
   </summary>
 
+  - Major: Icon component does not always apply `icon-base` to the SVGs -- please compose from its stylesheet.
+  - Patch: Custom field inputs expand to meet their layout container widths.
+  - Patch: Custom field date input has a nicer calendar icon.
 </details>
 
 ## 0.19.1 (May 4, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Patch: Custom field inputs expand to meet their layout container widths.
   - Patch: Custom field date input has a nicer calendar icon.
   - Minor: Custom field input single-choice component is implemented
+  - Patch: Custom field input single-choice component's SVGs are updated
 </details>
 
 ## 0.19.2 (May 7, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Major: Icon component does not always apply `icon-base` to the SVGs -- please compose from its stylesheet.
   - Patch: Custom field inputs expand to meet their layout container widths.
   - Patch: Custom field date input has a nicer calendar icon.
+  - Minor: Custom field input single-choice component is implemented
 </details>
 
 ## 0.19.2 (May 7, 2020)

--- a/src/components/custom-field-input-date/__snapshots__/custom-field-input-date.test.jsx.snap
+++ b/src/components/custom-field-input-date/__snapshots__/custom-field-input-date.test.jsx.snap
@@ -32,21 +32,17 @@ exports[`src/components/custom-field-input-date/custom-field-input-date has defa
       step={1}
       type="date"
     />
-    <div
-      className="input-icon-container"
+    <svg
+      className="icon-base size-medium fill-gray stroke-gray color-transparent"
+      role="img"
     >
-      <svg
-        className="icon-base size-medium fill-gray stroke-gray color-transparent"
-        role="img"
-      >
-        <title>
-          Hello
-        </title>
-        <use
-          xlinkHref="#icon-calendar-fill.svg"
-        />
-      </svg>
-    </div>
+      <title>
+        Hello
+      </title>
+      <use
+        xlinkHref="#icon-calendar-fill.svg"
+      />
+    </svg>
   </div>
 </div>
 `;

--- a/src/components/custom-field-input-date/__snapshots__/custom-field-input-date.test.jsx.snap
+++ b/src/components/custom-field-input-date/__snapshots__/custom-field-input-date.test.jsx.snap
@@ -33,7 +33,7 @@ exports[`src/components/custom-field-input-date/custom-field-input-date has defa
       type="date"
     />
     <svg
-      className="icon-base size-medium fill-gray stroke-gray color-transparent"
+      className="input-icon size-medium color-transparent"
       role="img"
     >
       <title>

--- a/src/components/custom-field-input-date/custom-field-input-date.jsx
+++ b/src/components/custom-field-input-date/custom-field-input-date.jsx
@@ -4,6 +4,7 @@ import calendarSvg from '../../svgs/icon-calendar-fill.svg';
 import Icon from '../icon/icon.jsx';
 import CustomFieldInputText from '../custom-field-input-text/custom-field-input-text.jsx';
 import { convertToFormat, validDate } from './format/format-date.js';
+import styles from '../custom-field-input-text/custom-field-input-text.css';
 
 const isValidInput = (value) => {
   if (value === '' || value === undefined) {
@@ -70,7 +71,7 @@ export default function CustomFieldInputDate(props) {
   const sharedProps = {
     className: props.className,
     disabled: props.disabled,
-    icon: <Icon name={calendarSvg.id} title={props.label} stroke="gray" fill="gray" />,
+    icon: <Icon className={styles['input-icon']} name={calendarSvg.id} title={props.label} stroke="gray" fill="gray" />,
     label: props.label,
     inputRef,
     readOnly: true,

--- a/src/components/custom-field-input-date/custom-field-input-date.jsx
+++ b/src/components/custom-field-input-date/custom-field-input-date.jsx
@@ -71,7 +71,7 @@ export default function CustomFieldInputDate(props) {
   const sharedProps = {
     className: props.className,
     disabled: props.disabled,
-    icon: <Icon className={styles['input-icon']} name={calendarSvg.id} title={props.label} stroke="gray" fill="gray" />,
+    icon: <Icon className={styles['input-icon']} name={calendarSvg.id} title={props.label} stroke="skip" fill="skip" />,
     label: props.label,
     inputRef,
     readOnly: true,

--- a/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
+++ b/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
@@ -9,6 +9,7 @@ exports[`src/components/custom-field-input-single-choice/custom-field-input-sing
   </label>
   <input
     id="yo"
+    required={false}
   />
 </div>
 `;

--- a/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
+++ b/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
@@ -30,6 +30,14 @@ exports[`src/components/custom-field-input-single-choice/custom-field-input-sing
       required={false}
       type="text"
     />
+    <svg
+      className="input-icon size-medium stroke-none color-transparent"
+      role="img"
+    >
+      <use
+        xlinkHref="#icon-caret-down.svg"
+      />
+    </svg>
   </div>
 </div>
 `;

--- a/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
+++ b/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
@@ -1,15 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`src/components/custom-field-input-single-choice/custom-field-input-single-choice has defaults 1`] = `
-<div>
-  <label
-    htmlFor="yo"
+<div
+  className="custom-field-input-text"
+  data-testid="custom-field-input"
+>
+  <div
+    className="heading-container"
   >
-    Foo
-  </label>
-  <input
-    id="yo"
-    required={false}
-  />
+    <label
+      className="label"
+      htmlFor="yo"
+    >
+      Foo
+    </label>
+  </div>
+  <div
+    className="input-container"
+  >
+    <input
+      className="input"
+      disabled={false}
+      id="yo"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyUp={[Function]}
+      readOnly={false}
+      required={false}
+      type="text"
+    />
+  </div>
 </div>
 `;

--- a/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
+++ b/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
@@ -1,3 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src/components/custom-field-input-single-choice/custom-field-input-single-choice has defaults 1`] = `<div />`;
+exports[`src/components/custom-field-input-single-choice/custom-field-input-single-choice has defaults 1`] = `
+<div>
+  <div>
+    <label
+      htmlFor="selectmeplease"
+    >
+      
+    </label>
+    <select
+      id="selectmeplease"
+      name="selectmeplease"
+    />
+  </div>
+</div>
+`;

--- a/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
+++ b/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
@@ -2,16 +2,14 @@
 
 exports[`src/components/custom-field-input-single-choice/custom-field-input-single-choice has defaults 1`] = `
 <div>
-  <div>
-    <label
-      htmlFor="selectmeplease"
-    >
-      
-    </label>
-    <select
-      id="selectmeplease"
-      name="selectmeplease"
-    />
-  </div>
+  <label
+    htmlFor="yo"
+  >
+    
+  </label>
+  <input
+    id="yo"
+    name="selectmeplease"
+  />
 </div>
 `;

--- a/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
+++ b/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`src/components/custom-field-input-single-choice/custom-field-input-single-choice has defaults 1`] = `<div />`;

--- a/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
+++ b/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
@@ -5,7 +5,7 @@ exports[`src/components/custom-field-input-single-choice/custom-field-input-sing
   <label
     htmlFor="yo"
   >
-    
+    Foo
   </label>
   <input
     id="yo"

--- a/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
+++ b/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
@@ -9,7 +9,6 @@ exports[`src/components/custom-field-input-single-choice/custom-field-input-sing
   </label>
   <input
     id="yo"
-    name="selectmeplease"
   />
 </div>
 `;

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -1,16 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import CustomFieldInputText from '../custom-field-input-text/custom-field-input-text.jsx';
 
 export default function CustomFieldInputSingleChoice(props) {
   return (
-    <div>
-      <label htmlFor={props.id}>{props.label}</label>
-      <input
-        id={props.id}
-        defaultValue={props.value}
-        required={props.required}
-      />
-    </div>
+    <CustomFieldInputText
+      id={props.id}
+      label={props.label}
+      reqired={props.required}
+      value={props.value}
+    />
   );
 }
 

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -15,8 +15,8 @@ export default function CustomFieldInputSingleChoice(props) {
 }
 
 CustomFieldInputSingleChoice.propTypes = {
-  label: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
   required: PropTypes.bool,
   value: PropTypes.string,
 };

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -11,10 +11,8 @@ export default function CustomFieldInputSingleChoice(props) {
 }
 
 CustomFieldInputSingleChoice.propTypes = {
-  label: PropTypes.string,
+  label: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
 };
 
-CustomFieldInputSingleChoice.defaultProps = {
-  label: '',
-};
+CustomFieldInputSingleChoice.defaultProps = {};

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -5,7 +5,10 @@ export default function CustomFieldInputSingleChoice(props) {
   return (
     <div>
       <label htmlFor={props.id}>{props.label}</label>
-      <input id={props.id} name="selectmeplease" />
+      <input
+        id={props.id}
+        defaultValue={props.value}
+      />
     </div>
   );
 }
@@ -13,6 +16,9 @@ export default function CustomFieldInputSingleChoice(props) {
 CustomFieldInputSingleChoice.propTypes = {
   label: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
+  value: PropTypes.string,
 };
 
-CustomFieldInputSingleChoice.defaultProps = {};
+CustomFieldInputSingleChoice.defaultProps = {
+  value: undefined,
+};

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -1,5 +1,21 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-export default function CustomFieldInputSingleChoice() {
-  return (<div />);
+export default function CustomFieldInputSingleChoice(props) {
+  return (
+    <div>
+      <div>
+        <label htmlFor="selectmeplease">{props.label}</label>
+        <select id="selectmeplease" name="selectmeplease" />
+      </div>
+    </div>
+  );
 }
+
+CustomFieldInputSingleChoice.propTypes = {
+  label: PropTypes.string,
+};
+
+CustomFieldInputSingleChoice.defaultProps = {
+  label: '',
+};

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -7,6 +7,7 @@ export default function CustomFieldInputSingleChoice(props) {
     <CustomFieldInputText
       id={props.id}
       label={props.label}
+      placeholder={props.placeholder}
       readOnly={props.readOnly}
       required={props.required}
       value={props.value}
@@ -17,12 +18,14 @@ export default function CustomFieldInputSingleChoice(props) {
 CustomFieldInputSingleChoice.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
   value: PropTypes.string,
 };
 
 CustomFieldInputSingleChoice.defaultProps = {
+  placeholder: undefined,
   readOnly: false,
   required: false,
   value: undefined,

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import CustomFieldInputText from '../custom-field-input-text/custom-field-input-text.jsx';
+import Icon from '../icon/icon.jsx';
+import iconCaretDown from '../../svgs/icon-caret-down.svg';
+import iconCaretDownDisabled from '../../svgs/icon-caret-down-disabled.svg';
+import styles from '../custom-field-input-text/custom-field-input-text.css';
 
 export default function CustomFieldInputSingleChoice(props) {
   return (
     <CustomFieldInputText
+      icon={<Icon className={styles['input-icon']} name={props.readOnly ? iconCaretDownDisabled.id : iconCaretDown.id} fill="skip" />}
       id={props.id}
       label={props.label}
       placeholder={props.placeholder}

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -7,7 +7,7 @@ export default function CustomFieldInputSingleChoice(props) {
     <CustomFieldInputText
       id={props.id}
       label={props.label}
-      reqired={props.required}
+      required={props.required}
       value={props.value}
     />
   );

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -8,6 +8,7 @@ export default function CustomFieldInputSingleChoice(props) {
       <input
         id={props.id}
         defaultValue={props.value}
+        required={props.required}
       />
     </div>
   );
@@ -16,9 +17,11 @@ export default function CustomFieldInputSingleChoice(props) {
 CustomFieldInputSingleChoice.propTypes = {
   label: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
+  required: PropTypes.bool,
   value: PropTypes.string,
 };
 
 CustomFieldInputSingleChoice.defaultProps = {
+  required: false,
   value: undefined,
 };

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -4,16 +4,15 @@ import PropTypes from 'prop-types';
 export default function CustomFieldInputSingleChoice(props) {
   return (
     <div>
-      <div>
-        <label htmlFor="selectmeplease">{props.label}</label>
-        <select id="selectmeplease" name="selectmeplease" />
-      </div>
+      <label htmlFor={props.id}>{props.label}</label>
+      <input id={props.id} name="selectmeplease" />
     </div>
   );
 }
 
 CustomFieldInputSingleChoice.propTypes = {
   label: PropTypes.string,
+  id: PropTypes.string.isRequired,
 };
 
 CustomFieldInputSingleChoice.defaultProps = {

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function CustomFieldInputSingleChoice() {
+  return (<div />);
+}

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -7,6 +7,7 @@ export default function CustomFieldInputSingleChoice(props) {
     <CustomFieldInputText
       id={props.id}
       label={props.label}
+      readOnly={props.readOnly}
       required={props.required}
       value={props.value}
     />
@@ -16,11 +17,13 @@ export default function CustomFieldInputSingleChoice(props) {
 CustomFieldInputSingleChoice.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
+  readOnly: PropTypes.bool,
   required: PropTypes.bool,
   value: PropTypes.string,
 };
 
 CustomFieldInputSingleChoice.defaultProps = {
+  readOnly: false,
   required: false,
   value: undefined,
 };

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.md
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.md
@@ -9,12 +9,12 @@ The `CustomFieldInputSingleChoice` component represents the UI for a custom fiel
 />
 ```
 
-### Disabled Examples
+### Read-only examples
 
 ```jsx
 <CustomFieldInputSingleChoice
-  disabled
-  id="disabled-example-1"
-  label="Disabled Example 1"
+  id="read-only-example-1"
+  label="Read Only Example 1"
+  readOnly
 />
 ```

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.md
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.md
@@ -6,6 +6,7 @@ The `CustomFieldInputSingleChoice` component represents the UI for a custom fiel
 <CustomFieldInputSingleChoice
   id="default-example-1"
   label="Default Example 1"
+  placeholder="This is a single choice field"
 />
 ```
 

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.md
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.md
@@ -1,6 +1,6 @@
 The `CustomFieldInputSingleChoice` component represents the UI for a custom field of type single choice from Mavenlink's API.
 
-### Default Examples
+### Default examples
 
 ```jsx
 <CustomFieldInputSingleChoice

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.md
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.md
@@ -1,6 +1,6 @@
 The `CustomFieldInputSingleChoice` component represents the UI for a custom field of type single choice from Mavenlink's API.
 
-# Default
+### Default Examples
 
 ```jsx
 <CustomFieldInputSingleChoice
@@ -9,7 +9,8 @@ The `CustomFieldInputSingleChoice` component represents the UI for a custom fiel
 />
 ```
 
-# Disabled:
+### Disabled Examples
+
 ```jsx
 <CustomFieldInputSingleChoice
   disabled

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.md
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.md
@@ -8,6 +8,12 @@ The `CustomFieldInputSingleChoice` component represents the UI for a custom fiel
   label="Default Example 1"
   placeholder="This is a single choice field"
 />
+
+<CustomFieldInputSingleChoice
+  id="default-example-1"
+  label="Default Example 1"
+  value="I am a value"
+/>
 ```
 
 ### Read-only examples
@@ -17,5 +23,12 @@ The `CustomFieldInputSingleChoice` component represents the UI for a custom fiel
   id="read-only-example-1"
   label="Read Only Example 1"
   readOnly
+/>
+
+<CustomFieldInputSingleChoice
+  id="read-only-example-1"
+  label="Read Only Example 1"
+  readOnly
+  value="I am a value"
 />
 ```

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.md
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.md
@@ -1,0 +1,19 @@
+The `CustomFieldInputSingleChoice` component represents the UI for a custom field of type single choice from Mavenlink's API.
+
+# Default
+
+```jsx
+<CustomFieldInputSingleChoice
+  id="default-example-1"
+  label="Default Example 1"
+/>
+```
+
+# Disabled:
+```jsx
+<CustomFieldInputSingleChoice
+  disabled
+  id="disabled-example-1"
+  label="Disabled Example 1"
+/>
+```

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
@@ -26,4 +26,11 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
       expect(getByLabelText('Foo')).toHaveAttribute('id', 'this-is-an-id');
     });
   });
+
+  describe('value API', () => {
+    it('accepts a value', () => {
+      const { getByLabelText } = renderComponent({ value: 'Some selection' });
+      expect(getByLabelText('Foo')).toHaveValue('Some selection');
+    });
+  });
 });

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
@@ -12,4 +12,11 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
     const tree = renderer.create(<CustomFieldInputSingleChoice />).toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  describe('label API', () => {
+    it('accepts a label', () => {
+      const { getByLabelText } = renderComponent({ label: 'Foo' });
+      expect(getByLabelText('Foo')).toBeDefined();
+    });
+  });
 });

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
@@ -4,26 +4,26 @@ import renderer from 'react-test-renderer';
 import CustomFieldInputSingleChoice from './custom-field-input-single-choice.jsx';
 
 describe('src/components/custom-field-input-single-choice/custom-field-input-single-choice', () => {
-  const renderComponent = (props = {}) => render(<CustomFieldInputSingleChoice id="yooo" {...props} />);
+  const renderComponent = (props = {}) => render(<CustomFieldInputSingleChoice label="Foo" id="yooo" {...props} />);
 
   afterEach(cleanup);
 
   it('has defaults', () => {
-    const tree = renderer.create(<CustomFieldInputSingleChoice id="yo" />).toJSON();
+    const tree = renderer.create(<CustomFieldInputSingleChoice label="Foo" id="yo" />).toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   describe('label API', () => {
     it('accepts a label', () => {
-      const { getByLabelText } = renderComponent({ label: 'Foo' });
-      expect(getByLabelText('Foo')).toBeDefined();
+      const { getByLabelText } = renderComponent({ label: 'Bar' });
+      expect(getByLabelText('Bar')).toBeDefined();
     });
   });
 
   describe('id API', () => {
     it('accepts an ID', () => {
-      const { getByLabelText } = renderComponent({ label: 'Foo', id: 'yooo' });
-      expect(getByLabelText('Foo')).toHaveAttribute('id', 'yooo');
+      const { getByLabelText } = renderComponent({ id: 'this-is-an-id' });
+      expect(getByLabelText('Foo')).toHaveAttribute('id', 'this-is-an-id');
     });
   });
 });

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
@@ -13,17 +13,17 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
     expect(tree).toMatchSnapshot();
   });
 
-  describe('label API', () => {
-    it('accepts a label', () => {
-      const { getByLabelText } = renderComponent({ label: 'Bar' });
-      expect(getByLabelText('Bar')).toBeDefined();
-    });
-  });
-
   describe('id API', () => {
     it('accepts an ID', () => {
       const { getByLabelText } = renderComponent({ id: 'this-is-an-id' });
       expect(getByLabelText('Foo')).toHaveAttribute('id', 'this-is-an-id');
+    });
+  });
+
+  describe('label API', () => {
+    it('accepts a label', () => {
+      const { getByLabelText } = renderComponent({ label: 'Bar' });
+      expect(getByLabelText('Bar')).toBeDefined();
     });
   });
 

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
@@ -27,6 +27,13 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
     });
   });
 
+  describe('placeholder API', () => {
+    it('accepts a placeholder', () => {
+      const { getByLabelText } = renderComponent({ placeholder: 'I am place' });
+      expect(getByLabelText('Foo')).toHaveAttribute('placeholder', 'I am place');
+    });
+  });
+
   describe('readOnly API', () => {
     it('sets the readonly attribute', () => {
       const { getByLabelText } = renderComponent({ readOnly: true });

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
@@ -4,12 +4,12 @@ import renderer from 'react-test-renderer';
 import CustomFieldInputSingleChoice from './custom-field-input-single-choice.jsx';
 
 describe('src/components/custom-field-input-single-choice/custom-field-input-single-choice', () => {
-  const renderComponent = (props = {}) => render(<CustomFieldInputSingleChoice {...props} />);
+  const renderComponent = (props = {}) => render(<CustomFieldInputSingleChoice id="yooo" {...props} />);
 
   afterEach(cleanup);
 
   it('has defaults', () => {
-    const tree = renderer.create(<CustomFieldInputSingleChoice />).toJSON();
+    const tree = renderer.create(<CustomFieldInputSingleChoice id="yo" />).toJSON();
     expect(tree).toMatchSnapshot();
   });
 
@@ -17,6 +17,13 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
     it('accepts a label', () => {
       const { getByLabelText } = renderComponent({ label: 'Foo' });
       expect(getByLabelText('Foo')).toBeDefined();
+    });
+  });
+
+  describe('id API', () => {
+    it('accepts an ID', () => {
+      const { getByLabelText } = renderComponent({ label: 'Foo', id: 'yooo' });
+      expect(getByLabelText('Foo')).toHaveAttribute('id', 'yooo');
     });
   });
 });

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import renderer from 'react-test-renderer';
+import CustomFieldInputSingleChoice from './custom-field-input-single-choice.jsx';
+
+describe('src/components/custom-field-input-single-choice/custom-field-input-single-choice', () => {
+  const renderComponent = (props = {}) => render(<CustomFieldInputSingleChoice {...props} />);
+
+  afterEach(cleanup);
+
+  it('has defaults', () => {
+    const tree = renderer.create(<CustomFieldInputSingleChoice />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
@@ -34,6 +34,18 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
     });
   });
 
+  describe('readOnly API', () => {
+    it('sets the readonly attribute', () => {
+      const { getByLabelText } = renderComponent({ readOnly: true });
+      expect(getByLabelText('Foo')).toHaveAttribute('readonly', '');
+    });
+
+    it('unsets the readonly attribute', () => {
+      const { getByLabelText } = renderComponent({ readOnly: false });
+      expect(getByLabelText('Foo')).not.toHaveAttribute('readonly', '');
+    });
+  });
+
   describe('required API', () => {
     it('sets the required attribute', () => {
       const { getByLabelText } = renderComponent({ required: true });

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
@@ -27,13 +27,6 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
     });
   });
 
-  describe('value API', () => {
-    it('accepts a value', () => {
-      const { getByLabelText } = renderComponent({ value: 'Some selection' });
-      expect(getByLabelText('Foo')).toHaveValue('Some selection');
-    });
-  });
-
   describe('readOnly API', () => {
     it('sets the readonly attribute', () => {
       const { getByLabelText } = renderComponent({ readOnly: true });
@@ -55,6 +48,13 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
     it('unsets the required attribute', () => {
       const { getByLabelText } = renderComponent({ required: false });
       expect(getByLabelText('Foo')).not.toBeRequired();
+    });
+  });
+
+  describe('value API', () => {
+    it('accepts a value', () => {
+      const { getByLabelText } = renderComponent({ value: 'Some selection' });
+      expect(getByLabelText('Foo')).toHaveValue('Some selection');
     });
   });
 });

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
@@ -33,4 +33,16 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
       expect(getByLabelText('Foo')).toHaveValue('Some selection');
     });
   });
+
+  describe('required API', () => {
+    it('sets the required attribute', () => {
+      const { getByLabelText } = renderComponent({ required: true });
+      expect(getByLabelText('Foo')).toBeRequired();
+    });
+
+    it('unsets the required attribute', () => {
+      const { getByLabelText } = renderComponent({ required: false });
+      expect(getByLabelText('Foo')).not.toBeRequired();
+    });
+  });
 });

--- a/src/components/custom-field-input-text/custom-field-input-text.css
+++ b/src/components/custom-field-input-text/custom-field-input-text.css
@@ -27,9 +27,11 @@
 .input {
   border: 1px solid var(--palette-grey-light);
   border-radius: var(--spacing-x-small);
+  box-sizing: border-box;
   color: var(--palette-grey-x-dark);
   font-size: var(--mavenlink-type-base-size);
   padding: var(--spacing-medium);
+  width: 100%;
 }
 
 .input:disabled {
@@ -48,20 +50,20 @@
 .input-container {
   height: 34px;
   margin: var(--spacing-small) 0;
+  position: relative;
+  width: 100%;
 }
 
 .input-container input::placeholder {
   color: var(--palette-grey-dark);
 }
 
-.input-icon-container {
-  display: inline-block;
-  height: 20px;
-  position: absolute;
-  margin-left: -28px;
-  margin-top: var(--spacing-small);
+.input-icon {
+  composes: icon-base from '../icon/icon.css';
   pointer-events: none;
-  width: 20px;
+  position: absolute;
+  right: 6px;
+  top: 6px;
 }
 
 .label {

--- a/src/components/custom-field-input-text/custom-field-input-text.css
+++ b/src/components/custom-field-input-text/custom-field-input-text.css
@@ -30,7 +30,7 @@
   box-sizing: border-box;
   color: var(--palette-grey-x-dark);
   font-size: var(--mavenlink-type-base-size);
-  padding: var(--spacing-medium);
+  padding: 6px var(--spacing-x-large) 7px var(--spacing-medium);
   width: 100%;
 }
 

--- a/src/components/custom-field-input-text/custom-field-input-text.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.jsx
@@ -88,11 +88,7 @@ export default function CustomFieldInputText(props) {
           step={props.step}
           type={props.type}
         />
-        {showIcon() &&
-          <div className={styles['input-icon-container']}>
-            { icon() }
-          </div>
-        }
+        {showIcon() && icon()}
       </div>
       {props.error && <span className={styles.help}>{validationMessage}</span>}
     </div>

--- a/src/components/icon/icon.css
+++ b/src/components/icon/icon.css
@@ -7,8 +7,6 @@
 }
 
 .icon-base {
-  height: var(--iconSizeMedium);
-  width: var(--iconSizeMedium);
   display: inline-block;
   vertical-align: middle;
 }

--- a/src/components/icon/icon.jsx
+++ b/src/components/icon/icon.jsx
@@ -4,12 +4,11 @@ import styles from './icon.css';
 
 export default function Icon({ className, name, size, stroke, fill, currentColor, title }) {
   const classes = [
-    styles['icon-base'],
+    className,
     styles[`size-${size}`],
     fill === 'skip' ? '' : styles[`fill-${fill}`],
     stroke === 'skip' ? '' : styles[`stroke-${stroke}`],
     currentColor === 'skip' ? '' : styles[`color-${currentColor}`],
-    className,
   ].filter(Boolean);
 
   return (
@@ -59,7 +58,7 @@ Icon.propTypes = {
 };
 
 Icon.defaultProps = {
-  className: undefined,
+  className: styles['icon-base'],
   fill: 'none',
   currentColor: 'transparent',
   size: 'medium',

--- a/src/components/icon/icon.jsx
+++ b/src/components/icon/icon.jsx
@@ -6,9 +6,9 @@ export default function Icon({ className, name, size, stroke, fill, currentColor
   const classes = [
     styles['icon-base'],
     styles[`size-${size}`],
-    styles[`fill-${fill}`],
-    styles[`stroke-${stroke}`],
-    styles[`color-${currentColor}`],
+    fill === 'skip' ? '' : styles[`fill-${fill}`],
+    stroke === 'skip' ? '' : styles[`stroke-${stroke}`],
+    currentColor === 'skip' ? '' : styles[`color-${currentColor}`],
     className,
   ].filter(Boolean);
 
@@ -29,6 +29,7 @@ Icon.propTypes = {
     'caution',
     'gray',
     'none',
+    'skip',
   ]),
   currentColor: PropTypes.oneOf([
     'primary',
@@ -37,6 +38,7 @@ Icon.propTypes = {
     'caution',
     'gray',
     'transparent',
+    'skip',
   ]),
   name: PropTypes.string.isRequired,
   size: PropTypes.oneOf([
@@ -51,6 +53,7 @@ Icon.propTypes = {
     'caution',
     'gray',
     'none',
+    'skip',
   ]),
   title: PropTypes.string,
 };

--- a/src/components/icon/icon.test.jsx
+++ b/src/components/icon/icon.test.jsx
@@ -42,6 +42,13 @@ describe('Icon', () => {
   });
 
   describe('className API', () => {
+    it('has a class name', () => {
+      render((
+        <Icon name="foobar" size="large" className="i-am-a-classname" />
+      ));
+      expect(screen.getByRole('img')).toHaveClass('i-am-a-classname');
+    });
+
     describe('fill', () => {
       it('can be "primary"', () => {
         render((

--- a/src/components/icon/icon.test.jsx
+++ b/src/components/icon/icon.test.jsx
@@ -77,6 +77,19 @@ describe('Icon', () => {
         ));
         expect(screen.getByRole('img')).toHaveClass('fill-none');
       });
+
+      it('can be "skip"', () => {
+        render((
+          <Icon name="foobar" fill="skip" />
+        ));
+
+        expect(screen.getByRole('img')).not.toHaveClass('fill-primary');
+        expect(screen.getByRole('img')).not.toHaveClass('fill-action');
+        expect(screen.getByRole('img')).not.toHaveClass('fill-highlight');
+        expect(screen.getByRole('img')).not.toHaveClass('fill-caution');
+        expect(screen.getByRole('img')).not.toHaveClass('fill-none');
+        expect(screen.getByRole('img')).not.toHaveClass('fill-skip');
+      });
     });
 
     describe('stroke', () => {
@@ -114,6 +127,19 @@ describe('Icon', () => {
         ));
         expect(screen.getByRole('img')).toHaveClass('stroke-none');
       });
+
+      it('can be "skip"', () => {
+        render((
+          <Icon name="foobar" stroke="skip" />
+        ));
+
+        expect(screen.getByRole('img')).not.toHaveClass('stroke-primary');
+        expect(screen.getByRole('img')).not.toHaveClass('stroke-action');
+        expect(screen.getByRole('img')).not.toHaveClass('stroke-highlight');
+        expect(screen.getByRole('img')).not.toHaveClass('stroke-caution');
+        expect(screen.getByRole('img')).not.toHaveClass('stroke-none');
+        expect(screen.getByRole('img')).not.toHaveClass('stroke-skip');
+      });
     });
 
     describe('currentColor', () => {
@@ -150,6 +176,19 @@ describe('Icon', () => {
           <Icon name="foobar" currentColor="transparent" />
         ));
         expect(screen.getByRole('img')).toHaveClass('color-transparent');
+      });
+
+      it('can be "skip"', () => {
+        render((
+          <Icon name="foobar" currentColor="skip" />
+        ));
+
+        expect(screen.getByRole('img')).not.toHaveClass('color-primary');
+        expect(screen.getByRole('img')).not.toHaveClass('color-action');
+        expect(screen.getByRole('img')).not.toHaveClass('color-highlight');
+        expect(screen.getByRole('img')).not.toHaveClass('color-caution');
+        expect(screen.getByRole('img')).not.toHaveClass('color-none');
+        expect(screen.getByRole('img')).not.toHaveClass('color-skip');
       });
     });
   });

--- a/src/svgs/icon-caret-down-disabled.svg
+++ b/src/svgs/icon-caret-down-disabled.svg
@@ -1,13 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="10px" height="6px" viewBox="0 0 10 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 64 (93537) - https://sketch.com -->
-    <title>Icons/Zz Working/Caret/Down</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Forms" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" fill-opacity="0.38" opacity="0.568498884">
-        <g id="Forms/Select/Disabled-w-value" transform="translate(-99.000000, -14.000000)" fill="#000000" fill-rule="nonzero">
-            <g id="Icons/Zz-Working/Caret/Down" transform="translate(88.000000, 0.000000)">
-                <path d="M15.9999914,17.1546376 L19.3310353,14.2567059 C19.7415453,13.8872468 20.3738351,13.9205252 20.7432941,14.3310353 C21.1127532,14.7415453 21.0794748,15.3738351 20.6689647,15.7432941 L16.6689647,19.2432941 C16.2886598,19.5855686 15.7113402,19.5855686 15.3310353,19.2432941 L11.3310353,15.7432941 C10.9205252,15.3738351 10.8872468,14.7415453 11.2567059,14.3310353 C11.6261649,13.9205252 12.2584547,13.8872468 12.6689647,14.2567059 L15.9999914,17.1546376 Z" id="line"></path>
-            </g>
-        </g>
-    </g>
+<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Down Caret - Disabled</title>
+  <g id="Down-Caret---Disabled" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" fill-opacity="0.574710446">
+    <path d="M10,10.1546462 L13.3310439,7.25671445 C13.7415539,6.88725543 14.3738437,6.92053385 14.7433027,7.33104387 C15.1127618,7.74155389 15.0794834,8.37384373 14.6689733,8.74330275 L10.6689733,12.2433027 C10.2886684,12.5855772 9.71134884,12.5855772 9.33104387,12.2433027 L5.33104387,8.74330275 C4.92053385,8.37384373 4.88725543,7.74155389 5.25671445,7.33104387 C5.62617347,6.92053385 6.25846331,6.88725543 6.66897333,7.25671445 L10,10.1546462 Z" id="line" fill="#757575" fill-rule="nonzero"></path>
+  </g>
 </svg>

--- a/src/svgs/icon-caret-down-disabled.svg
+++ b/src/svgs/icon-caret-down-disabled.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="10px" height="6px" viewBox="0 0 10 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 64 (93537) - https://sketch.com -->
+    <title>Icons/Zz Working/Caret/Down</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Forms" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" fill-opacity="0.38" opacity="0.568498884">
+        <g id="Forms/Select/Disabled-w-value" transform="translate(-99.000000, -14.000000)" fill="#000000" fill-rule="nonzero">
+            <g id="Icons/Zz-Working/Caret/Down" transform="translate(88.000000, 0.000000)">
+                <path d="M15.9999914,17.1546376 L19.3310353,14.2567059 C19.7415453,13.8872468 20.3738351,13.9205252 20.7432941,14.3310353 C21.1127532,14.7415453 21.0794748,15.3738351 20.6689647,15.7432941 L16.6689647,19.2432941 C16.2886598,19.5855686 15.7113402,19.5855686 15.3310353,19.2432941 L11.3310353,15.7432941 C10.9205252,15.3738351 10.8872468,14.7415453 11.2567059,14.3310353 C11.6261649,13.9205252 12.2584547,13.8872468 12.6689647,14.2567059 L15.9999914,17.1546376 Z" id="line"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/svgs/icon-caret-down.svg
+++ b/src/svgs/icon-caret-down.svg
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="32px" height="32px" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 64 (93537) - https://sketch.com -->
-    <title>Icons/Zz Working/Caret/Down</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Icons/Zz-Working/Caret/Down" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" fill-opacity="0.38">
-        <path d="M15.9999914,17.1546376 L19.3310353,14.2567059 C19.7415453,13.8872468 20.3738351,13.9205252 20.7432941,14.3310353 C21.1127532,14.7415453 21.0794748,15.3738351 20.6689647,15.7432941 L16.6689647,19.2432941 C16.2886598,19.5855686 15.7113402,19.5855686 15.3310353,19.2432941 L11.3310353,15.7432941 C10.9205252,15.3738351 10.8872468,14.7415453 11.2567059,14.3310353 C11.6261649,13.9205252 12.2584547,13.8872468 12.6689647,14.2567059 L15.9999914,17.1546376 Z" id="line" fill="#000000" fill-rule="nonzero"></path>
-    </g>
+<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Down Caret</title>
+  <g id="Down-Caret" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" fill-opacity="0.38">
+    <path d="M10,10.1546462 L13.3310439,7.25671445 C13.7415539,6.88725543 14.3738437,6.92053385 14.7433027,7.33104387 C15.1127618,7.74155389 15.0794834,8.37384373 14.6689733,8.74330275 L10.6689733,12.2433027 C10.2886684,12.5855772 9.71134884,12.5855772 9.33104387,12.2433027 L5.33104387,8.74330275 C4.92053385,8.37384373 4.88725543,7.74155389 5.25671445,7.33104387 C5.62617347,6.92053385 6.25846331,6.88725543 6.66897333,7.25671445 L10,10.1546462 Z" id="line" fill="#000000" fill-rule="nonzero"></path>
+  </g>
 </svg>

--- a/src/svgs/icon-caret-down.svg
+++ b/src/svgs/icon-caret-down.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="32px" height="32px" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 64 (93537) - https://sketch.com -->
+    <title>Icons/Zz Working/Caret/Down</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Icons/Zz-Working/Caret/Down" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" fill-opacity="0.38">
+        <path d="M15.9999914,17.1546376 L19.3310353,14.2567059 C19.7415453,13.8872468 20.3738351,13.9205252 20.7432941,14.3310353 C21.1127532,14.7415453 21.0794748,15.3738351 20.6689647,15.7432941 L16.6689647,19.2432941 C16.2886598,19.5855686 15.7113402,19.5855686 15.3310353,19.2432941 L11.3310353,15.7432941 C10.9205252,15.3738351 10.8872468,14.7415453 11.2567059,14.3310353 C11.6261649,13.9205252 12.2584547,13.8872468 12.6689647,14.2567059 L15.9999914,17.1546376 Z" id="line" fill="#000000" fill-rule="nonzero"></path>
+    </g>
+</svg>

--- a/styleguide/webpack.config.js
+++ b/styleguide/webpack.config.js
@@ -29,16 +29,6 @@ module.exports = {
           },
           {
             loader: 'svgo-loader',
-            options: {
-              plugins: [
-                { removeTitle: true },
-                { removeNonInheritableGroupAttrs: true },
-                { removeUselessStrokeAndFill: false },
-                { collapseGroups: true },
-                { convertColors: { shorthex: false } },
-                { convertPathData: false },
-              ],
-            },
           },
         ],
       },

--- a/styleguide/webpack.config.js
+++ b/styleguide/webpack.config.js
@@ -37,12 +37,6 @@ module.exports = {
                 { collapseGroups: true },
                 { convertColors: { shorthex: false } },
                 { convertPathData: false },
-                {
-                  removeAttrs: {
-                    attrs: '(fill|stroke)',
-                    preserveCurrentColor: true,
-                  },
-                },
               ],
             },
           },

--- a/styleguide/webpack.config.js
+++ b/styleguide/webpack.config.js
@@ -24,12 +24,8 @@ module.exports = {
           /src\/svgs\//,
         ],
         use: [
-          {
-            loader: 'svg-sprite-loader',
-          },
-          {
-            loader: 'svgo-loader',
-          },
+          { loader: 'svg-sprite-loader' },
+          { loader: 'svgo-loader' },
         ],
       },
       {


### PR DESCRIPTION
## Motivation

* Create a custom field input for choices

## Acceptance Criteria

- There is a (read only) single choice field in external MDS 
  - Only required to build the read only path
  - Component without value
  - Component with value
  - Component is  readonly: disabled but focusabled
- [Engineering] Publish a new MDS version

## Change log entry

- Major: Icon component does not always apply `icon-base` to the SVGs -- please compose from its stylesheet.
- Patch: Custom field inputs expand to meet their layout container widths.
- Patch: Custom field date input has a nicer calendar icon.

<details>
<summary>PR upkeep checklist</summary>
<br />

- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-single-choice-early-in-the-morning-172540830
- [x] (Optional) [Pivotal Tracker Story](https://www.pivotaltracker.com/story/show/172540830)
- [x] (Mandatory) ["Ode to Viceroy" by Mac DeMarco](https://www.youtube.com/watch?v=6bfTTeZOrs4)
- [x] (When ready for review) Reviewer(s)

</details>
