### PR TITLE
Webinf row row row your section 172923835

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   </summary>
 
   - Minor: Add Section component
+  - Minor: Add SectionRow component
 </details>
 
 ## 0.20.3 (May 15, 2020)

--- a/src/components/section-row/__snapshots__/section-row.test.jsx.snap
+++ b/src/components/section-row/__snapshots__/section-row.test.jsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Section Row renders a section-row component 1`] = `
+<div
+  className="section-row"
+/>
+`;

--- a/src/components/section-row/section-row.css
+++ b/src/components/section-row/section-row.css
@@ -1,0 +1,10 @@
+@import '../../styles/spacing.css';
+
+.section-row {
+  display: flex;
+}
+
+.section-row > *:not(:last-child) {
+  margin: 0;
+  margin-right: var(--spacing-x-large);
+}

--- a/src/components/section-row/section-row.jsx
+++ b/src/components/section-row/section-row.jsx
@@ -1,0 +1,19 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styles from './section-row.css';
+
+export default function SectionRow(props) {
+  return (
+    <div className={styles['section-row']}>
+      {props.children}
+    </div>
+  );
+}
+
+SectionRow.propTypes = {
+  children: PropTypes.node,
+};
+
+SectionRow.defaultProps = {
+  children: undefined,
+};

--- a/src/components/section-row/section-row.md
+++ b/src/components/section-row/section-row.md
@@ -1,0 +1,19 @@
+`SectionRow`s are designed to complement `Section`s, allowing a design-spec approach to a "table-like" to component layout. They use specific spacing between child components. They should only be used as containers, and within a `Section` component.
+
+```
+<Section
+  title="Project Details"
+  description="These fields allow control of custom project fields."
+>
+  <SectionRow>
+    <CustomFieldInputText
+      id="test-id-1"
+      label="Project Sub Name"
+    />
+    <CustomFieldInputText
+      id="test-id-2"
+      label="Project Direct Report"
+    />
+  </SectionRow>
+</Section>
+```

--- a/src/components/section-row/section-row.test.jsx
+++ b/src/components/section-row/section-row.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { render, screen } from '@testing-library/react';
+import SectionRow from './section-row.jsx';
+
+describe('Section Row', () => {
+  it('renders a section-row component', () => {
+    const tree = renderer
+      .create((
+        <SectionRow />
+      )).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('can have child elements', () => {
+    render(<SectionRow><span>Test Label</span></SectionRow>);
+    expect(screen.getByText('Test Label').tagName).toEqual('SPAN');
+  });
+});

--- a/src/components/section/section.md
+++ b/src/components/section/section.md
@@ -1,4 +1,6 @@
-Sections can be used to semantically group controls, information, and inputs. Sections get the `region` ARIA role by default, and the `title` prop is required to support accessibility with a contained heading. For now, the section component should only be used in Custom Apps, while the "page layout" spec is still in flux.
+`Section`s can be used to semantically group controls, information, and inputs. `Section`s get the `region` ARIA role by default, and the `title` prop is required to support accessibility with a contained heading. For now, the `Section` component should only be used in Custom Apps, while the "page layout" spec is still in flux.
+
+For rows that should contain more than one full-length component, a `SectionRow` should be used to wrap thse children.
 
 ```
 <Section
@@ -7,7 +9,7 @@ Sections can be used to semantically group controls, information, and inputs. Se
 />
 ```
 
-Sections can contain child elements, like any other element:
+`Section`s can contain child elements, like any other element:
 ```
 <Section
   title="Project Details"
@@ -21,7 +23,7 @@ Sections can contain child elements, like any other element:
     id="test-id-2"
     label="Project Direct Report"
   />
-  <div style={{display: 'flex', justifyContent: 'space-around'}}>
+  <SectionRow>
     <CustomFieldInputText
       id="test-id-3"
       label="Project Sub Report 1"
@@ -30,11 +32,11 @@ Sections can contain child elements, like any other element:
       id="test-id-4"
       label="Project Sub Report 2"
     />
-  </div>
+  </SectionRow>
 </Section>
 ```
 
-Sections can be siblings with proper spacing, and with things like form submission containers:
+`Section`s can be siblings with proper spacing, and with things like form submission containers:
 ```
 <Section
   title="Top Section"


### PR DESCRIPTION
## Motivation
We want a way to meet the design criteria for spacing in rows of components, when a row resides in a section component.

## Acceptance Criteria 
- Elements inside a row component are spaced (16px) according to the design doc spec for sections: https://docs.google.com/document/d/16Gw8jZYPPDr1IeDydk48qVtD0D06gX7Wy4Wz-zpbF3w/edit
- Elements do not take the full width of the container, and do not wrap to the "next line"

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-row-row-row-your-section-172923835
- [x] (When ready for review) Reviewer(s)

[Pivotal Story](https://www.pivotaltracker.com/story/show/172923835)
