### PR TITLE
Leverage CI workspace instead of cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ jobs:
       - persist_to_workspace:
           root: ~/repo
           paths:
+            - ./
             - node_modules
       - run: yarn lint
       - run: yarn test
@@ -62,7 +63,6 @@ jobs:
       - image: circleci/node:10.18.0
     working_directory: ~/repo
     steps:
-      - checkout
       - attach_workspace:
           at: ~/repo
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,10 @@ jobs:
       - install_dependencies:
           image: "cypress"
           version: "10.18.0"
+      - persist_to_workspace:
+          root: ~/repo
+          paths:
+            - node_modules
       - run: yarn lint
       - run: yarn test
       - run:
@@ -59,9 +63,8 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - install_dependencies:
-          image: "node"
-          version: "10.18.0"
+      - attach_workspace:
+          at: ~/repo
       - run: |
           git config user.email "ci-deployment@mavenlink"
           git config user.name "CI Deployment"


### PR DESCRIPTION
## Motivation

Restoring cache in `deploy` is about a minute. It is weird since we already have the dependencies from the test job. 

## Acceptance Criteria 

- Attaching workspace is faster than 20 seconds (thus faster than restoring cache)
- CI is green

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [ ] Deployment URL: https://mavenlink.github.io/design-system/faster_ci
- [x] (When ready for review) Reviewer(s)
