### PR TITLE
Add typography-v2 css variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Minor: Add ariaLabel to Icon props
   - Minor: Add ariaLabelledBy to Icon props
   - Minor: Add id to Icon props
+  - Minor: Add typography-v2 CSS variables
 </details>
 
 ## 0.22.0 (May 22, 2020)

--- a/src/styles/typography-v2.css
+++ b/src/styles/typography-v2.css
@@ -1,0 +1,9 @@
+:root {
+  --mds-type-font-family: 'Open Sans', system-ui, sans-serif;
+  --mds-type-page-title: 400 22px var(--mds-type-font-family);
+  --mds-type-subhead-1: 600 16px var(--mds-type-font-family);
+  --mds-type-subhead-2: 400 16px var(--mds-type-font-family);
+  --mds-type-subhead-3: 600 14px var(--mds-type-font-family);
+  --mds-type-subhead-4: 400 12px var(--mds-type-font-family);
+  --mds-type-content: 400 14px var(--mds-type-font-family);
+}

--- a/src/styles/typography-v2.css
+++ b/src/styles/typography-v2.css
@@ -4,6 +4,6 @@
   --mds-type-subhead-1: 600 16px var(--mds-type-font-family);
   --mds-type-subhead-2: 400 16px var(--mds-type-font-family);
   --mds-type-subhead-3: 600 14px var(--mds-type-font-family);
-  --mds-type-subhead-4: 400 12px var(--mds-type-font-family);
+  --mds-type-subtext: 400 12px var(--mds-type-font-family);
   --mds-type-content: 400 14px var(--mds-type-font-family);
 }


### PR DESCRIPTION
## Motivation

Once design has documentation around typography rules, we want to formalize these rules in a CSS file as CSS variables.

https://docs.google.com/document/d/1sjAkrfez_jitKGnhU834K7w_CKRvPJG6kQ04LXn2lWk/edit

## Acceptance Criteria 

- CSS file with typography rules as CSS variables
- CSS variables are versioned (e.g. smallFontV1)
- CSS variables follow a new "mds-typography-value" pattern

https://www.pivotaltracker.com/story/show/172248330

Deployment URL: https://mavenlink.github.io/design-system/webinf-tokenize-me-typography-captain-172248330


Helpful link for reviewers:
https://developer.mozilla.org/en-US/docs/Web/CSS/font