### PR TITLE
Forward refs to Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   - Append new items to make git merging easier.
 </details>
 
+## 0.27.0 (June 23, 2020)
+- Minor: Forward refs to `Button`
+
 ## 0.26.0 (June 22, 2020)
 - Minor: Implement `FormControl` component
 - Major: Use `FormControl` for `Input`, `CustomFieldInputText`, , `CustomFieldInputNumber`, `CustomFieldInputCurrency`, `CustomFieldInputDate`, `CustomFieldInputSingleChoice`

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -2,21 +2,23 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styles from './button.css';
 
-export default function Button(props) {
-  return (
-    <button
-      className={props.className || styles[props.color]}
-      disabled={props.disabled}
-      id={props.id}
-      name={props.name}
-      onClick={props.onClick}
-      type={props.type}
-      value={props.value}
-    >
-      {props.children}
-    </button>
-  );
-}
+const Button = React.forwardRef(
+  function Button(props, ref) {
+    return (
+      <button
+        className={props.className || styles[props.color]}
+        disabled={props.disabled}
+        id={props.id}
+        name={props.name}
+        onClick={props.onClick}
+        type={props.type}
+        value={props.value}
+        ref={ref}
+      >
+        {props.children}
+      </button>
+    );
+  });
 
 Button.propTypes = {
   className: PropTypes.string,
@@ -47,3 +49,5 @@ Button.defaultProps = {
   type: undefined,
   value: undefined,
 };
+
+export default Button;


### PR DESCRIPTION
Co-authored-by: Ada Ebling <aebling@mavenlink.com>

<!-- 
In order to reduce overhead in maintaing PRs, please follow these rules: 
1. If there is a pivotal story, replace the motivation+AC sections and add the pivotal story URL
2. If there is no pivotal story, fill in the motivation and AC sections
3. Complete the PR checklist
-->


## Pivotal story:
- [[DeleteTask] - Set focus on modal open/close](https://www.pivotaltracker.com/story/show/173454494)
- Summary: The Confirmation component uses ButtonV2, which uses mds/Button. In order to auto-focus on one of these buttons, we need to forward refs down the component tree.

## PR upkeep checklist

- [ ] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/forward-ref-button
- [x] (When ready for review) Reviewer(s)
