### PR TITLE
> Webinf some refactors

### DIFF
--- a/src/components/custom-field-input-currency/custom-field-input-currency.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.jsx
@@ -61,22 +61,6 @@ const CustomFieldInputCurrency = forwardRef(function CustomFieldInputCurrency(pr
     return [numberValue, props.currencyCode];
   });
 
-  useCustomFieldValue(props.id, ref, () => {
-    let numberValue;
-
-    if (isEditing) {
-      const currencyFractionDigits = currencyMetaData[props.currencyCode].maximumFractionDigits;
-
-      numberValue = parseFloat(
-        valueRef.current.value * (10 ** currencyFractionDigits),
-      );
-    } else {
-      numberValue = parseInt(valueRef.current.value.replace(/\D/g, ''), 10);
-    }
-
-    return [numberValue, props.currencyCode];
-  });
-
   function handleOnBlur(event) {
     if (numberRef.current.validity.valid) {
       setInput(parseFloat(event.target.value));

--- a/src/components/custom-field-input-currency/custom-field-input-currency.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.jsx
@@ -61,6 +61,22 @@ const CustomFieldInputCurrency = forwardRef(function CustomFieldInputCurrency(pr
     return [numberValue, props.currencyCode];
   });
 
+  useCustomFieldValue(props.id, ref, () => {
+    let numberValue;
+
+    if (isEditing) {
+      const currencyFractionDigits = currencyMetaData[props.currencyCode].maximumFractionDigits;
+
+      numberValue = parseFloat(
+        valueRef.current.value * (10 ** currencyFractionDigits),
+      );
+    } else {
+      numberValue = parseInt(valueRef.current.value.replace(/\D/g, ''), 10);
+    }
+
+    return [numberValue, props.currencyCode];
+  });
+
   function handleOnBlur(event) {
     if (numberRef.current.validity.valid) {
       setInput(parseFloat(event.target.value));

--- a/src/components/custom-field-input-currency/custom-field-input-currency.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.jsx
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
-import React, { forwardRef, useImperativeHandle, useState, useRef, useEffect } from 'react';
+import React, { forwardRef, useState, useRef, useEffect } from 'react';
 import CustomFieldInputText from '../custom-field-input-text/custom-field-input-text.jsx';
 import CustomFieldInputNumber from '../custom-field-input-number/custom-field-input-number.jsx';
 import currencyCodeType from './currency-code-type.js';
 import currencyMetaData from './currency-meta-data.js';
 import styles from '../__internal__/abstract-custom-field.css';
+import useCustomFieldValue from '../../hooks/use-custom-field-value.jsx';
 
 function getLocale() {
   if (navigator && navigator.languages) {
@@ -46,6 +47,19 @@ const CustomFieldInputCurrency = forwardRef(function CustomFieldInputCurrency(pr
   const [isFocused, setIsFocused] = useState(false);
   const numberRef = useRef(null);
   const valueRef = isEditing ? numberRef : componentRef;
+  useCustomFieldValue(props.id, ref, () => {
+    let numberValue;
+
+    if (isEditing) {
+      numberValue = parseFloat(
+        valueRef.current.value * (10 ** currencyMetaData[props.currencyCode].maximumFractionDigits),
+      );
+    } else {
+      numberValue = parseInt(valueRef.current.value.replace(/\D/g, ''), 10);
+    }
+
+    return [numberValue, props.currencyCode];
+  });
 
   function handleOnBlur(event) {
     if (numberRef.current.validity.valid) {
@@ -74,23 +88,6 @@ const CustomFieldInputCurrency = forwardRef(function CustomFieldInputCurrency(pr
       numberRef.current.focus();
     }
   });
-
-  useImperativeHandle(ref, () => ({
-    id: props.id,
-    get value() {
-      let numberValue;
-
-      if (isEditing) {
-        numberValue = parseFloat(
-          valueRef.current.value * (10 ** currencyMetaData[props.currencyCode].maximumFractionDigits),
-        );
-      } else {
-        numberValue = parseInt(valueRef.current.value.replace(/\D/g, ''), 10);
-      }
-
-      return [numberValue, props.currencyCode];
-    },
-  }));
 
   const sharedProps = {
     className: props.className,

--- a/src/components/custom-field-input-date/custom-field-input-date.jsx
+++ b/src/components/custom-field-input-date/custom-field-input-date.jsx
@@ -1,10 +1,11 @@
-import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import React, { forwardRef, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import calendarSvg from '../../svgs/icon-calendar-fill.svg';
 import Icon from '../icon/icon.jsx';
 import { convertToFormat, validDate } from './format/format-date.js';
 import styles from '../__internal__/abstract-custom-field.css';
 import AbstractCustomField from '../__internal__/abstract-custom-field.jsx';
+import useCustomFieldValue from '../../hooks/use-custom-field-value.jsx';
 
 const isValidInput = (value) => {
   if (value === '' || value === undefined) {
@@ -32,6 +33,7 @@ const CustomFieldInputDate = forwardRef(function CustomFieldInputDate(props, ref
   const [isEditing, setIsEditing] = useState(true);
   const [isValid, setIsValid] = useState(isValueValid(props.value, props.error, true));
   const [isFocused] = useState(false);
+  useCustomFieldValue(props.id, ref, () => componentRef.current.value);
 
   useEffect(() => {
     if (!inputRef.current) return;
@@ -52,13 +54,6 @@ const CustomFieldInputDate = forwardRef(function CustomFieldInputDate(props, ref
       inputRef.current.focus();
     }
   }, [isEditing, isFocused]);
-
-  useImperativeHandle(ref, () => ({
-    id: props.id,
-    get value() {
-      return componentRef.current.value;
-    },
-  }));
 
   const handleOnChange = (event) => {
     if (inputRef.current) {

--- a/src/components/custom-field-input-number/custom-field-input-number.jsx
+++ b/src/components/custom-field-input-number/custom-field-input-number.jsx
@@ -3,6 +3,7 @@ import React, { forwardRef, useImperativeHandle, useEffect, useRef, useState } f
 import styles from '../__internal__/abstract-custom-field.css';
 import useValidation from '../../hooks/use-validation.jsx';
 import AbstractCustomField from '../__internal__/abstract-custom-field.jsx';
+import useCustomFieldValue from '../../hooks/use-custom-field-value';
 
 const apiLimits = {
   max: 2 ** 31,
@@ -14,6 +15,7 @@ const CustomFieldInputNumber = forwardRef(function CustomFieldInputNumber(props,
 
   const validationMessage = useValidation(props.readOnly, props.errorText, inputRef);
   const [invalid, setInvalid] = useState(validationMessage !== '');
+  useCustomFieldValue(props.id, ref, () => inputRef.current.value);
 
   function handleOnKeyUp(event) {
     setInvalid(!event.target.checkValidity());
@@ -29,13 +31,6 @@ const CustomFieldInputNumber = forwardRef(function CustomFieldInputNumber(props,
     const hasError = props.errorText.length > 0;
     setInvalid(hasError);
   }, [props.errorText]);
-
-  useImperativeHandle(ref, () => ({
-    id: props.id,
-    get value() {
-      return inputRef.current.value;
-    },
-  }));
 
   return (
     <AbstractCustomField

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -19,7 +19,7 @@ const CustomFieldInputSingleChoice = forwardRef(function CustomFieldInputSingleC
   const [showOptions, setShowOptions] = useState(false);
   const [value, setValue] = useState(props.value);
   const [searchValue, setSearchValue] = useState(undefined);
-  useCustomFieldValue(props.id, ref, () => value);
+  useCustomFieldValue(props.id, ref, () => value || '');
 
   const inputRef = useRef();
   const refs = props.choices.map(() => useRef());

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -1,7 +1,6 @@
 import React, {
   forwardRef,
   useEffect,
-  useImperativeHandle,
   useRef,
   useState,
 } from 'react';
@@ -13,12 +12,14 @@ import iconCaretDownDisabled from '../../svgs/icon-caret-down-disabled.svg';
 import styles from './custom-field-input-single-choice.css';
 import Listbox from '../listbox/listbox.jsx';
 import ListOption from '../list-option/list-option.jsx';
+import useCustomFieldValue from '../../hooks/use-custom-field-value.jsx';
 
 const CustomFieldInputSingleChoice = forwardRef(function CustomFieldInputSingleChoice(props, ref) {
   const [didMount, setDidMount] = useState(false);
   const [showOptions, setShowOptions] = useState(false);
   const [value, setValue] = useState(props.value);
   const [searchValue, setSearchValue] = useState(undefined);
+  useCustomFieldValue(props.id, ref, () => value);
 
   const inputRef = useRef();
   const refs = props.choices.map(() => useRef());
@@ -106,13 +107,6 @@ const CustomFieldInputSingleChoice = forwardRef(function CustomFieldInputSingleC
     if (!didMount) return;
     if (!showOptions) inputRef.current.focus();
   }, [showOptions]);
-
-  useImperativeHandle(ref, () => ({
-    id: props.id,
-    get value() {
-      return value;
-    },
-  }));
 
   return (
     <div className={styles.container}>

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
@@ -233,6 +233,12 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
 
       expect(screen.getByText('hello')).toHaveAttribute('aria-selected', 'true');
     });
+
+    it('returns empty string when no value is provided', () => {
+      const ref = createRef();
+      render(<CustomFieldInputSingleChoice {...requiredProps} value={undefined} ref={ref} />);
+      expect(ref.current.value).toBe('');
+    });
   });
 
   describe('forwardRef API', () => {

--- a/src/components/custom-field-input-text/custom-field-input-text.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.jsx
@@ -8,13 +8,7 @@ const CustomFieldInputText = forwardRef(function CustomFieldInputText(props, ref
   const inputRef = props.inputRef || defaultRef;
 
   const validationMessage = useValidation(props.readOnly, props.errorText, inputRef);
-
-  useImperativeHandle(ref, () => ({
-    id: props.id,
-    get value() {
-      return inputRef.current.value;
-    },
-  }));
+  useImperativeHandle(props.id, ref, () => inputRef.current.value);
 
   return (
     <AbstractCustomField

--- a/src/hooks/use-custom-field-value.jsx
+++ b/src/hooks/use-custom-field-value.jsx
@@ -1,0 +1,10 @@
+import { useImperativeHandle } from 'react';
+
+export default function useCustomFieldValue(id, ref, getValue) {
+  useImperativeHandle(ref, () => ({
+    id,
+    get value() {
+      return getValue();
+    },
+  }));
+}


### PR DESCRIPTION
## Motivation

There was a discrepancy between the ref API of CustomFieldInputSingleChoice here and on big maven, and so I adjusted this to accommodate. This also pulls out the duplicated useImperativeHandle into its own hook specifically for custom fields.

## PR upkeep checklist

- [ ] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-currency-is-what-you-think-it-is-171681533
- [x] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
