### PR TITLE
Ensure markdown paragraphs are styled correctly

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -92,6 +92,13 @@ module.exports = {
     TableRenderer: path.join(__dirname, 'styleguide/components/table'),
   },
   styleguideDir: 'build',
+  styles: {
+    Para: {
+      para: {
+        fontSize: 14,
+      },
+    },
+  },
   template: {
     favicon: 'favicon.ico',
     head: {


### PR DESCRIPTION
Looks like Styleguidist might have a bug since it is not re-using the theme fontSizes

https://www.pivotaltracker.com/story/show/174214846
https://www.pivotaltracker.com/story/show/174263131

## PR upkeep checklist

- [x] Change log entry N/A
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/fix-site-typography
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check N/A
- [x] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
