### PR TITLE
Add defaultValue API to Input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Append new items to make git merging easier.
   - Minor: Calendar component dates can be navigated via keyboard
   - Minor: Calendar component year dropdown allows selecting a year
+  - Minor: Add `defaultValue` to `Input` component API
 </details>
 
 ## v0.38.0 (August 25, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
+  - Minor: Add `defaultValue` to `Input` component API
 </details>
 
 ## v0.39.3 (September 1, 2020)

--- a/src/components/input/input.jsx
+++ b/src/components/input/input.jsx
@@ -27,6 +27,7 @@ export default function Input(props) {
       <input
         autoFocus={props.autoFocus} // eslint-disable-line jsx-a11y/no-autofocus
         className={getClassName(props.className, props.invalid, props.readOnly)}
+        defaultValue={props.defaultValue}
         disabled={props.disabled}
         id={props.id}
         maxLength={props.maxLength}
@@ -52,6 +53,7 @@ Input.propTypes = {
   autoFocus: PropTypes.bool,
   className: PropTypes.string,
   cssContainer: PropTypes.string,
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
   inputRef: PropTypes.shape({ current: PropTypes.any }),
@@ -80,6 +82,7 @@ Input.defaultProps = {
   className: undefined,
   cssContainer: styles.container,
   cssLabel: undefined,
+  defaultValue: undefined,
   disabled: undefined,
   invalid: false,
   inputRef: undefined,

--- a/src/components/input/input.test.jsx
+++ b/src/components/input/input.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Input from './input.jsx';
 
 describe('Input', () => {
@@ -40,6 +41,24 @@ describe('Input', () => {
         />
       ));
       expect(screen.getByLabelText('the label').parentElement.parentElement).toHaveClass('test-class');
+    });
+  });
+
+  describe('defaultValue API', () => {
+    it('sets input value but input remains uncontrolled', () => {
+      render((
+        <Input
+          id="foo"
+          defaultValue="this is a test value"
+          label="the label"
+        />
+      ));
+
+      expect(screen.getByLabelText('the label')).toHaveValue('this is a test value');
+
+      userEvent.type(screen.getByLabelText('the label'), ' plus some more text');
+
+      expect(screen.getByLabelText('the label')).toHaveValue('this is a test value plus some more text');
     });
   });
 


### PR DESCRIPTION
## Motivation
We want to be able to provide a value to the input while keeping it uncontrolled.

## Acceptance Criteria 
- The `Input` component:
  - Has a `defaultValue` prop
  - The `defaultValue` is populated in the input
  - The input value can still be changed by the end user

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-gimme-dat-default-value-174560877
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
