### PR TITLE
Add submitText prop to form component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
+  - Minor: Add submitText prop to Form
 
 </details>
 

--- a/src/components/form/form.jsx
+++ b/src/components/form/form.jsx
@@ -76,7 +76,7 @@ const Form = React.forwardRef((props, forwardedRef) => {
             type="submit"
             disabled={!valid || !dirty}
           >
-            Save
+            {props.submitText}
           </Button>
         </div>
       }
@@ -85,6 +85,7 @@ const Form = React.forwardRef((props, forwardedRef) => {
 });
 
 Form.propTypes = {
+  submitText: PropTypes.string,
   children: PropTypes.func.isRequired,
   onChange: PropTypes.func,
   onSubmit: PropTypes.func,
@@ -95,6 +96,7 @@ Form.propTypes = {
 };
 
 Form.defaultProps = {
+  submitText: 'Save',
   onChange: () => {},
   onSubmit: () => {},
   readOnly: false,

--- a/src/components/form/form.test.jsx
+++ b/src/components/form/form.test.jsx
@@ -161,6 +161,13 @@ describe('<Form />', () => {
 
   describe('refs prop API', () => { /* Tested in usages */ });
 
+  describe('submitText API', () => {
+    it('can be set', () => {
+      render(<Form {...requiredProps} submitText="YOLO SWAG" />);
+      expect(screen.getByText('YOLO SWAG').type).toEqual('submit');
+    });
+  });
+
   describe('save button', () => {
     it('is enables/disables on changes', () => {
       const refs = [


### PR DESCRIPTION
## Motivation

* I need this to match the mock for the story I'm working on: https://www.pivotaltracker.com/story/show/174779185

## Acceptance Criteria 

* Can set submit text for submit button on form

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-form-needs-customizable-button-text
- [x] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
