### PR TITLE
Add maxLength attribute support to text and abstract custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Minor: Add new `Select` component
   - Minor: Refactor `CustomFieldInputSingleChoice` to use `Select`
   - Minor: Add new `setSelected` and `setVisible` methods to `ListOption` ref API
+  - Minor: Add maxLength attribute support to text and abstract custom fields
 </details>
 
 ## v0.43.3

--- a/src/components/__internal__/abstract-custom-field/abstract-custom-field.jsx
+++ b/src/components/__internal__/abstract-custom-field/abstract-custom-field.jsx
@@ -83,6 +83,7 @@ export default function AbstractCustomField(props) {
         id={props.id}
         role={props.inputRole}
         max={props.max}
+        maxLength={props.maxLength}
         min={props.min}
         name={props.name}
         onBlur={props.onBlur}
@@ -134,6 +135,10 @@ AbstractCustomField.propTypes = {
     PropTypes.number,
     PropTypes.string,
   ]),
+  maxLength: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
   min: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,
@@ -172,6 +177,7 @@ AbstractCustomField.defaultProps = {
   inputRef: undefined,
   inputRole: undefined,
   max: undefined,
+  maxLength: undefined,
   min: undefined,
   name: undefined,
   onBlur: () => {},

--- a/src/components/__internal__/abstract-custom-field/abstract-custom-field.test.jsx
+++ b/src/components/__internal__/abstract-custom-field/abstract-custom-field.test.jsx
@@ -113,6 +113,18 @@ describe('AbstractCustomField', () => {
     });
   });
 
+  describe('maxLength API', () => {
+    it('sets the maxLength (integer) attribute', () => {
+      render(<AbstractCustomField {...sharedProps} maxLength={5} />);
+      expect(screen.getByLabelText('Test label')).toHaveAttribute('maxLength', '5');
+    });
+
+    it('sets the maxLength (string) attribute', () => {
+      render(<AbstractCustomField {...sharedProps} maxLength="5" />);
+      expect(screen.getByLabelText('Test label')).toHaveAttribute('maxLength', '5');
+    });
+  });
+
   describe('label API', () => {
     it('sets the label', () => {
       render(<AbstractCustomField {...sharedProps} label="Another label" />);

--- a/src/components/custom-field-input-currency/custom-field-input-currency.test.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.test.jsx
@@ -39,7 +39,7 @@ describe('CustomFieldInputCurrency', () => {
   describe('prop-forward API', () => {
     it('forwards all props accepted by CustomFieldInputText on Object keys', () => {
       const excludedNumberProps = ['inputRef', 'max', 'min', 'onKeyUp', 'onKeyDown', 'step', 'onBlur', 'onFocus',
-        'type', 'readOnly', 'icon', 'onChange', 'onClick', 'ariaProps', 'defaultValue', 'errorText'];
+				   'type', 'readOnly', 'icon', 'onChange', 'onClick', 'ariaProps', 'defaultValue', 'errorText', 'maxLength'];
       const currencyProps = Object.keys(CustomFieldInputCurrency.propTypes);
       const inputTextProps = Object.keys(CustomFieldInputText.propTypes).filter(p => !excludedNumberProps.includes(p));
 

--- a/src/components/custom-field-input-currency/custom-field-input-currency.test.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.test.jsx
@@ -38,8 +38,8 @@ describe('CustomFieldInputCurrency', () => {
 
   describe('prop-forward API', () => {
     it('forwards all props accepted by CustomFieldInputText on Object keys', () => {
-      const excludedNumberProps = ['inputRef', 'max', 'min', 'onKeyUp', 'onKeyDown', 'step', 'onBlur', 'onFocus',
-				   'type', 'readOnly', 'icon', 'onChange', 'onClick', 'ariaProps', 'defaultValue', 'errorText', 'maxLength'];
+      const excludedNumberProps = ['inputRef', 'max', 'min', 'onKeyUp', 'onKeyDown', 'step', 'onBlur', 'onFocus', 'type',
+        'readOnly', 'icon', 'onChange', 'onClick', 'ariaProps', 'defaultValue', 'errorText', 'maxLength'];
       const currencyProps = Object.keys(CustomFieldInputCurrency.propTypes);
       const inputTextProps = Object.keys(CustomFieldInputText.propTypes).filter(p => !excludedNumberProps.includes(p));
 

--- a/src/components/custom-field-input-text/custom-field-input-text.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.jsx
@@ -31,6 +31,7 @@ const CustomFieldInputText = forwardRef(function CustomFieldInputText(props, ref
       id={props.id}
       inputRef={inputRef}
       label={props.label}
+      maxLength={props.maxLength}
       name={props.name}
       onBlur={props.onBlur}
       onChange={props.onChange}
@@ -62,6 +63,10 @@ CustomFieldInputText.propTypes = {
   id: PropTypes.string.isRequired,
   inputRef: PropTypes.shape({ current: PropTypes.any }),
   label: PropTypes.string.isRequired,
+  maxLength: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
   name: PropTypes.string,
   onBlur: PropTypes.func,
   onChange: PropTypes.func,
@@ -85,6 +90,7 @@ CustomFieldInputText.defaultProps = {
   disabled: false,
   errorText: '',
   inputRef: undefined,
+  maxLength: undefined,
   name: undefined,
   onBlur: () => {},
   onChange: () => {},


### PR DESCRIPTION
Co-authored-by: Eli Sullivan <esullivan@mavenlink.com>

<!-- 
In order to reduce overhead in maintaing PRs, please follow these rules: 
1. If there is a pivotal story, replace the motivation+AC sections and add the pivotal story URL
2. If there is no pivotal story, fill in the motivation and AC sections
3. Complete the PR checklist
-->


## Motivation


## Acceptance Criteria 


## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/add-max-length-prop
- [x] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
