### PR TITLE
Deprecate `inputRef` APIs on custom fields

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,13 +40,13 @@ commands:
 jobs:
   build_and_test:
     docker:
-      - image: cypress/base:10.18.0
+      - image: cypress/base:14
     working_directory: ~/repo
     steps:
       - checkout
       - install_dependencies:
           image: "cypress"
-          version: "10.18.0"
+          version: "14"
       - run: yarn lint
       - run: yarn test
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
+  - Major: Deprecate `inputRef` on CustomFieldInputNumber
 </details>
 
 ## v0.45.0

--- a/src/components/custom-field-input-currency/custom-field-input-currency.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.jsx
@@ -40,10 +40,10 @@ function formatValue(unitValue, currencyCode) {
 }
 
 const CustomFieldInputCurrency = forwardRef(function CustomFieldInputCurrency(props, ref) {
-  const componentRef = useRef(null);
   const [input, setInput] = useState(subunitToUnit(props.value, props.currencyCode));
   const [isEditing, setIsEditing] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
+  const componentRef = useRef(null);
   const numberRef = useRef(null);
   const valueRef = isEditing ? numberRef : componentRef;
 
@@ -119,7 +119,7 @@ const CustomFieldInputCurrency = forwardRef(function CustomFieldInputCurrency(pr
       <CustomFieldInputNumber
         {...sharedProps}
         onBlur={handleOnBlur}
-        inputRef={numberRef}
+        ref={numberRef}
         step={currencyMetaData[props.currencyCode].step}
         value={input}
       />

--- a/src/components/custom-field-input-number/__snapshots__/custom-field-input-number.test.jsx.snap
+++ b/src/components/custom-field-input-number/__snapshots__/custom-field-input-number.test.jsx.snap
@@ -40,8 +40,10 @@ exports[`CustomFieldInputNumber has defaults 1`] = `
 exports[`CustomFieldInputNumber has defaults 2`] = `
 Object {
   "dirty": false,
+  "focus": [Function],
   "id": "test-input",
   "name": "field-id",
+  "validity": ValidityState {},
   "value": "",
 }
 `;

--- a/src/components/custom-field-input-number/custom-field-input-number.jsx
+++ b/src/components/custom-field-input-number/custom-field-input-number.jsx
@@ -10,8 +10,7 @@ const apiLimits = {
 };
 
 const CustomFieldInputNumber = forwardRef(function CustomFieldInputNumber(props, ref) {
-  const fallbackRef = useRef(null);
-  const inputRef = props.inputRef || fallbackRef;
+  const inputRef = useRef(null);
 
   const [checkedValidity, setCheckedValidity] = useState(false);
   const validationMessage = useValidation(props.readOnly, props.errorText, inputRef, checkedValidity);
@@ -31,8 +30,14 @@ const CustomFieldInputNumber = forwardRef(function CustomFieldInputNumber(props,
       const providedValue = props.value ? String(props.value) : '';
       return providedValue !== this.value;
     },
+    focus: () => {
+      return inputRef.current.focus();
+    },
     id: props.id,
     name: props.name,
+    get validity() {
+      return inputRef.current.validity;
+    },
     get value() {
       return inputRef.current.value;
     },
@@ -68,7 +73,6 @@ CustomFieldInputNumber.propTypes = {
   disabled: PropTypes.bool,
   errorText: PropTypes.string,
   id: PropTypes.string.isRequired,
-  inputRef: PropTypes.shape({ current: PropTypes.any }),
   label: PropTypes.string.isRequired,
   name: PropTypes.string,
   onBlur: PropTypes.func,
@@ -84,7 +88,6 @@ CustomFieldInputNumber.defaultProps = {
   className: styles['custom-field-input-text'],
   disabled: false,
   errorText: '',
-  inputRef: undefined,
   name: undefined,
   onBlur: () => {},
   placeholder: undefined,

--- a/src/components/custom-field-input-number/custom-field-input-number.test.jsx
+++ b/src/components/custom-field-input-number/custom-field-input-number.test.jsx
@@ -72,6 +72,16 @@ describe('CustomFieldInputNumber', () => {
     });
   });
 
+  describe('focus ref API', () => {
+    it('focuses the input', () => {
+      const ref = createRef();
+      render(<CustomFieldInputNumber {...requiredProps} ref={ref} />);
+      expect(screen.getByLabelText('Test label')).not.toBe(document.activeElement);
+      ref.current.focus();
+      expect(screen.getByLabelText('Test label')).toBe(document.activeElement);
+    });
+  });
+
   describe('id API', () => {
     it('sets the id attribute', () => {
       render(<CustomFieldInputNumber {...requiredProps} id="test-id" />);
@@ -110,6 +120,14 @@ describe('CustomFieldInputNumber', () => {
     it('unsets the required attribute', () => {
       render(<CustomFieldInputNumber {...requiredProps} />);
       expect(screen.getByLabelText('Test label')).not.toBeRequired();
+    });
+  });
+
+  describe('validity ref API', () => {
+    it('is the DOM validity state', () => {
+      const ref = createRef();
+      render(<CustomFieldInputNumber {...requiredProps} ref={ref} />);
+      expect(ref.current.validity).toBe(screen.getByLabelText('Test label').validity);
     });
   });
 
@@ -157,14 +175,6 @@ describe('CustomFieldInputNumber', () => {
       const { getByLabelText } = render(<CustomFieldInputNumber {...requiredProps} label="foo" onBlur={onBlur} />);
       fireEvent.blur(getByLabelText('foo'));
       expect(onBlur.mock.calls.length).toEqual(1);
-    });
-  });
-
-  describe('inputRef API', () => {
-    it('sets the ref on the input', () => {
-      const inputRef = createRef();
-      render(<CustomFieldInputNumber {...requiredProps} inputRef={inputRef} />);
-      expect(screen.getByLabelText('Test label')).toBe(inputRef.current);
     });
   });
 

--- a/src/components/custom-field-input-text/custom-field-input-text.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.jsx
@@ -4,8 +4,7 @@ import useValidation from '../../hooks/use-validation.jsx';
 import AbstractCustomField from '../__internal__/abstract-custom-field/abstract-custom-field.jsx';
 
 const CustomFieldInputText = forwardRef(function CustomFieldInputText(props, ref) {
-  const defaultRef = useRef(null);
-  const inputRef = props.inputRef || defaultRef;
+  const inputRef = useRef(null);
 
   const validationMessage = useValidation(props.readOnly, props.errorText, inputRef);
 
@@ -61,7 +60,6 @@ CustomFieldInputText.propTypes = {
   disabled: PropTypes.bool,
   errorText: PropTypes.string,
   id: PropTypes.string.isRequired,
-  inputRef: PropTypes.shape({ current: PropTypes.any }),
   label: PropTypes.string.isRequired,
   maxLength: PropTypes.oneOfType([
     PropTypes.number,
@@ -89,7 +87,6 @@ CustomFieldInputText.defaultProps = {
   defaultValue: undefined,
   disabled: false,
   errorText: '',
-  inputRef: undefined,
   maxLength: undefined,
   name: undefined,
   onBlur: () => {},

--- a/src/components/custom-field-input-text/custom-field-input-text.test.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.test.jsx
@@ -51,14 +51,6 @@ describe('CustomFieldInputText', () => {
     });
   });
 
-  describe('inputRef API', () => {
-    it('sets the ref on the input', () => {
-      const inputRef = createRef();
-      render(<CustomFieldInputText {...requiredProps} inputRef={inputRef} />);
-      expect(screen.getByLabelText('Test label')).toBe(inputRef.current);
-    });
-  });
-
   describe('value API', () => {
     it('sets the value attribute', () => {
       render(<CustomFieldInputText {...requiredProps} value="test-value" />);


### PR DESCRIPTION
We want to encourage pure usages of the React ref component APIs. If we need to reach deeper into a component, it needs to be part of the components `ref` prop API.

Closes #198 

https://www.pivotaltracker.com/story/show/175104430

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/mds-refs
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check https://github.com/mavenlink/mavenlink/pull/21718
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?) N/A
