### PR TITLE
Internal MDS inputs look good when required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
-  - Patch: Explicitly set `FormControl` label to `display: inline`.
+  - Patch: Explicitly set `FormControl` label to `display: inline`
+  - Patch: Use the correct MDS color for the "(Required)" part of `FormControl` labels
 </details>
 
 ## v0.46.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
+  - Patch: Explicitly set `FormControl` label to `display: inline`.
 </details>
 
 ## v0.46.0

--- a/src/components/form-control/form-control.css
+++ b/src/components/form-control/form-control.css
@@ -4,6 +4,7 @@
 
 .label {
   color: var(--mds-grey-54);
+  display: inline;
   font-family: var(--mavenlink-type-font-family); /* stylelint-disable-line mds/typography */
   font-size: var(--mavenlink-type-small-size); /* stylelint-disable-line mds/typography */
 }

--- a/src/components/form-control/form-control.css
+++ b/src/components/form-control/form-control.css
@@ -21,7 +21,7 @@
 
 .invalid-required {
   composes: required;
-  color: var(--mds-red-100);
+  color: var(--mds-red-text);
 }
 
 .control-container {


### PR DESCRIPTION
## Motivation
Look like there is some CSS pollution on our MDS inputs when applied to bigmaven.

## Acceptance Criteria 
- When the input is `required`, the input label uses the MDS red text color
- When the input is `required`, it uses the same styling as the external MDS inputs

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-we-require-more-minerals-175021353
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check
- [x] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
