### PR TITLE
Fix issue where presentDateString was not considering the user's timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
+  - Patch: Fix timezone issue with `CustomFieldInputDate`
 </details>
 
 ## v0.48.0

--- a/src/components/custom-field-input-date/custom-field-input-date.jsx
+++ b/src/components/custom-field-input-date/custom-field-input-date.jsx
@@ -36,7 +36,8 @@ function presentDateString(dateString) {
     return '';
   }
 
-  const date = new Date(Date.parse(dateString));
+  const timezone = new Date().toLocaleTimeString('en-us', { timeZoneName: 'short' }).split(' ')[2];
+  const date = new Date(`${dateString}  00:00:00 ${timezone}`);
   return date.toLocaleDateString(undefined, { month: 'short', year: 'numeric', day: 'numeric' });
 }
 


### PR DESCRIPTION
## Motivation
Timezone bug for date input component 
https://www.pivotaltracker.com/story/show/175209475

## Acceptance Criteria
The presented date should match that date of the value.

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-timezoner-175209475
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check: https://github.com/mavenlink/mavenlink/pull/21873
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
