### PR TITLE
Add valid property to CustomFieldInputText on ref API

### DIFF
--- a/src/components/custom-field-input-text/__snapshots__/custom-field-input-text.test.jsx.snap
+++ b/src/components/custom-field-input-text/__snapshots__/custom-field-input-text.test.jsx.snap
@@ -38,6 +38,7 @@ Object {
   "dirty": false,
   "id": "test-input",
   "name": "field-id",
+  "valid": true,
   "value": "",
 }
 `;

--- a/src/components/custom-field-input-text/custom-field-input-text.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.jsx
@@ -15,6 +15,9 @@ const CustomFieldInputText = forwardRef(function CustomFieldInputText(props, ref
     },
     id: props.id,
     name: props.name,
+    get valid() {
+      return inputRef.current.checkValidity();
+    },
     get value() {
       return inputRef.current.value;
     },

--- a/src/components/custom-field-input-text/custom-field-input-text.test.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.test.jsx
@@ -67,4 +67,13 @@ describe('CustomFieldInputText', () => {
       expect(inputRef.current.value).toBe('test-value');
     });
   });
+
+  describe('validity API', () => {
+    it('indicates if the native HTML input is valid', () => {
+      const ref = createRef(null);
+      render(<CustomFieldInputText id="test-input" label="Test label" ref={ref} required value="" />);
+      expect(ref.current.valid).not.toBeUndefined();
+      expect(ref.current.valid).toEqual(false);
+    });
+  });
 });


### PR DESCRIPTION
## Motivation

I need to know if my text field is valid.

## Acceptance Criteria

* Has validity API as part of providing a ref

## PR upkeep checklist

- [ ] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-project-tab-title-early-in-the-morning-174890882
- [x] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
