### PR TITLE
Toggle the code snippets to make it easier to QA accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
+  - Minor: Add Toggle Code button to all component examples in order to better accessibility QA
 </details>
 
 ## v0.48.0

--- a/styleguide/components/react-component/react-component.jsx
+++ b/styleguide/components/react-component/react-component.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 import Pathline from 'rsg-components/Pathline'; // eslint-disable-line import/extensions
 import styles from './react-component.css';
 
@@ -13,6 +13,23 @@ export default function ReactComponent({
   tabButtons,
   tabBody,
 }) {
+  const [examplesToShow, setExamplesToShow] = useState({ ...examples });
+  const [toggleCode, setToggleCode] = useState(false);
+
+  const onToggleCodeClick = () => {
+    setToggleCode(!toggleCode);
+    setExamplesToShow({
+      ...examplesToShow,
+      props: {
+        ...examplesToShow.props,
+        settings: {
+          showcode: false,
+        },
+        exampleMode: toggleCode ? 'expand' : 'hide',
+      },
+    });
+  };
+
   return (
     <div className={styles.root} id={`${name}-container`}>
       <header className={styles.header}>
@@ -25,8 +42,9 @@ export default function ReactComponent({
           {docs}
         </div>
       )}
+      <button onClick={onToggleCodeClick}>Toggle Code</button>
       <div className={styles.examples}>
-        {examples}
+        {examplesToShow}
       </div>
       {tabButtons && (
         <div className={styles.tabs}>


### PR DESCRIPTION
## Motivation
https://www.pivotaltracker.com/story/show/174202359

Code example on:
<img width="604" alt="Screen Shot 2020-10-13 at 12 13 29 PM" src="https://user-images.githubusercontent.com/2433091/95902411-02c6e280-0d52-11eb-93a4-1dc4dc5e083c.png">

Code example off:
<img width="612" alt="Screen Shot 2020-10-13 at 12 13 32 PM" src="https://user-images.githubusercontent.com/2433091/95902397-fd699800-0d51-11eb-9403-fcf59e37f6f6.png">


## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-mds-toggle-code-174202359
- [x] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
