### PR TITLE
Check ref.current before running debounce onSubmit function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
   - Patch: `Select`, `CustomFieldInputSingleChoice` maintains correct input value state when closing dropdown
+  - Patch: `Form` now checks for `ref.current` before invoking debounced onSubmit callback
 </details>
 
 ## v0.48.0

--- a/src/components/form/form.jsx
+++ b/src/components/form/form.jsx
@@ -18,7 +18,7 @@ const Form = React.forwardRef((props, forwardedRef) => {
   const [valid, setValid] = useState(true);
 
   const onDebouncedSubmit = useCallback(debounce(() => {
-    if (ref.current.checkValidity() && ref.current.dirty) {
+    if (ref.current && ref.current.checkValidity() && ref.current.dirty) {
       props.onSubmit({
         target: ref.current,
         data: props.refs.reduce((data, controlRef) => {


### PR DESCRIPTION
## Motivation
`ref.current === null` case is causing issues for bigmaven tests, we don't want that.

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/fix-form-debounce-initial
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
