### PR TITLE
Add autoComplete prop for Abstract, use in Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
+  - Minor: Add `autoComplete` prop to `AbstractCustomField`
+  - Minor: Set `autoComplete="off"` for `Select` component
 </details>
 
 ## v0.48.2

--- a/src/components/__internal__/abstract-custom-field/abstract-custom-field.jsx
+++ b/src/components/__internal__/abstract-custom-field/abstract-custom-field.jsx
@@ -117,7 +117,7 @@ export default function AbstractCustomField(props) {
 }
 
 AbstractCustomField.propTypes = {
-  autoComplete: PropTypes.oneOf(["off", "on"]),
+  autoComplete: PropTypes.oneOf(['off', 'on']),
   ariaProps: PropTypes.shape({
     autocomplete: PropTypes.string,
     controls: PropTypes.string,
@@ -173,7 +173,7 @@ AbstractCustomField.propTypes = {
 };
 
 AbstractCustomField.defaultProps = {
-  autoComplete: "on",
+  autoComplete: 'on',
   ariaProps: {},
   className: undefined,
   inputClassName: undefined,

--- a/src/components/__internal__/abstract-custom-field/abstract-custom-field.jsx
+++ b/src/components/__internal__/abstract-custom-field/abstract-custom-field.jsx
@@ -76,6 +76,7 @@ export default function AbstractCustomField(props) {
       required={props.required}
     >
       <input
+        autoComplete={props.autoComplete}
         aria-autocomplete={props.ariaProps.autocomplete}
         aria-controls={props.ariaProps.controls}
         aria-haspopup={props.ariaProps.haspopup}
@@ -116,6 +117,7 @@ export default function AbstractCustomField(props) {
 }
 
 AbstractCustomField.propTypes = {
+  autoComplete: PropTypes.oneOf(["off", "on"]),
   ariaProps: PropTypes.shape({
     autocomplete: PropTypes.string,
     controls: PropTypes.string,
@@ -171,6 +173,7 @@ AbstractCustomField.propTypes = {
 };
 
 AbstractCustomField.defaultProps = {
+  autoComplete: "on",
   ariaProps: {},
   className: undefined,
   inputClassName: undefined,

--- a/src/components/__internal__/abstract-custom-field/abstract-custom-field.test.jsx
+++ b/src/components/__internal__/abstract-custom-field/abstract-custom-field.test.jsx
@@ -10,6 +10,18 @@ describe('AbstractCustomField', () => {
     id: 'test-id',
   };
 
+  describe('autoComplete API', () => {
+    it('can be autoComplete on', () => {
+      render(<AbstractCustomField {...sharedProps} autoComplete="on" />);
+      expect(screen.getByLabelText('Test label')).toHaveAttribute('autocomplete', 'on');
+    });
+
+    it('can be autoComplete off', () => {
+      render(<AbstractCustomField {...sharedProps} autoComplete="off" />);
+      expect(screen.getByLabelText('Test label')).toHaveAttribute('autocomplete', 'off');
+    });
+  });
+
   describe('aria props', () => {
     const ariaProps = { autocomplete: 'list', haspopup: 'listbox', controls: 'test-dropdown' };
 

--- a/src/components/custom-field-input-currency/__snapshots__/custom-field-input-currency.test.jsx.snap
+++ b/src/components/custom-field-input-currency/__snapshots__/custom-field-input-currency.test.jsx.snap
@@ -18,6 +18,7 @@ exports[`CustomFieldInputCurrency has defaults 1`] = `
         class="control-container"
       >
         <input
+          autocomplete="on"
           class="input"
           id="currency"
           name="some-field-id"

--- a/src/components/custom-field-input-date/__snapshots__/custom-field-input-date.test.jsx.snap
+++ b/src/components/custom-field-input-date/__snapshots__/custom-field-input-date.test.jsx.snap
@@ -19,6 +19,7 @@ exports[`src/components/custom-field-input-date/custom-field-input-date has defa
           class="control-container"
         >
           <input
+            autocomplete="on"
             class="input"
             id="field-date"
             style="--numIcon: 1;"

--- a/src/components/custom-field-input-number/__snapshots__/custom-field-input-number.test.jsx.snap
+++ b/src/components/custom-field-input-number/__snapshots__/custom-field-input-number.test.jsx.snap
@@ -18,6 +18,7 @@ exports[`CustomFieldInputNumber has defaults 1`] = `
         class="control-container"
       >
         <input
+          autocomplete="on"
           class="input"
           id="test-input"
           max="2147483648"

--- a/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
+++ b/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
@@ -20,10 +20,11 @@ exports[`src/components/custom-field-input-single-choice/custom-field-input-sing
           class="control-container"
         >
           <input
-            aria-autocomplete="list"
+            aria-autocomplete="none"
             aria-controls="test-id-single-choice-listbox"
             aria-expanded="false"
             aria-haspopup="listbox"
+            autocomplete="off"
             class="input"
             id="test-id"
             name="field-id"

--- a/src/components/custom-field-input-text/__snapshots__/custom-field-input-text.test.jsx.snap
+++ b/src/components/custom-field-input-text/__snapshots__/custom-field-input-text.test.jsx.snap
@@ -17,6 +17,7 @@ exports[`CustomFieldInputText has defaults 1`] = `
         class="control-container"
       >
         <input
+          autocomplete="on"
           class="input"
           id="test-input"
           name="field-id"

--- a/src/components/select/__snapshots__/select.test.jsx.snap
+++ b/src/components/select/__snapshots__/select.test.jsx.snap
@@ -20,10 +20,11 @@ exports[`src/components/select/select has defaults 1`] = `
           class="control-container"
         >
           <input
-            aria-autocomplete="list"
+            aria-autocomplete="none"
             aria-controls="test-id-single-choice-listbox"
             aria-expanded="false"
             aria-haspopup="listbox"
+            autocomplete="off"
             class="input"
             id="test-id"
             name="field-id"

--- a/src/components/select/select.jsx
+++ b/src/components/select/select.jsx
@@ -167,11 +167,12 @@ const Select = forwardRef(function Select(props, ref) {
         value={searchValue || defaultValue}
         inputRole={'combobox'}
         ariaProps={{
-          autocomplete: 'list',
+          autocomplete: 'none',
           controls: `${props.id}-single-choice-listbox`,
           expanded: showOptions,
           haspopup: 'listbox',
         }}
+        autoComplete="off"
       />
       { showOptions && (
         (!props.children || props.children.length === 0) ? (<NoOptions className={styles['no-options']} />) : (

--- a/src/components/select/select.test.jsx
+++ b/src/components/select/select.test.jsx
@@ -91,7 +91,7 @@ describe('src/components/select/select', () => {
     it('has aria-haspopup, role is combobox, aria-autocomplete is list, and aria-controls references the list box id', () => {
       render(<Select {...requiredProps}>{baseListOptionElements}</Select>);
       expect(screen.getByLabelText('Test label', { selector: '[aria-haspopup="listbox"]' })).toBeInTheDocument();
-      expect(screen.getByLabelText('Test label', { selector: 'input' })).toHaveAttribute('aria-autocomplete', 'list');
+      expect(screen.getByLabelText('Test label', { selector: 'input' })).toHaveAttribute('aria-autocomplete', 'none');
       expect(screen.getByLabelText('Test label', { selector: 'input' })).toHaveAttribute('aria-controls', 'test-id-single-choice-listbox');
     });
 


### PR DESCRIPTION
## Motivation
Don't show browser autofill when we already have the dropdown functionality. It blocks our dropdown for `Select`.

## Acceptance Criteria
- Browser does not show autofill popup for `Select` components in forms

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/no-more-chrome-autofill
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
