### PR TITLE
fix(CustomFieldInputMultipleChoice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Append new items to make git merging easier.
   - Minor: Add `autoComplete` prop to `AbstractCustomField`
   - Minor: Set `autoComplete="off"` for `Select` component
+  - Patch: Turn off autofill behavior in `CustomFieldInputMultipleChoice`
 </details>
 
 ## v0.48.2

--- a/src/components/custom-field-input-multiple-choice/__snapshots__/custom-field-input-multiple-choice.test.jsx.snap
+++ b/src/components/custom-field-input-multiple-choice/__snapshots__/custom-field-input-multiple-choice.test.jsx.snap
@@ -34,6 +34,7 @@ exports[`<CustomFieldInputMultipleChoice> has defaults 1`] = `
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="test-id-label"
+                autocomplete="off"
                 class="autocomplete-input"
                 id="test-id-autocomple"
                 role="combobox"

--- a/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.jsx
+++ b/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.jsx
@@ -164,6 +164,7 @@ const CustomFieldInputMultipleChoice = forwardRef((props, ref) => {
                 aria-expanded={renderPopup}
                 aria-haspopup="listbox"
                 aria-labelledby={`${props.id}-label`}
+                autoComplete="off"
                 role="combobox"
                 className={styles['autocomplete-input']}
                 id={`${props.id}-autocomple`}


### PR DESCRIPTION
## Motivation

Turn off browser autofill behavior in custom select component. We do not want two dropdowns when interactive with the multiple choice component.

## Acceptance Criteria

- Green build

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/fix-multi-autofill/
- [x] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check N/A
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?) N/A
