### PR TITLE
Webinf taglist nav has no memory of this place 173632521

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   - Minor: Enhance `Input` component with validation logic, ref API
   - Patch: Fix a11y descriptions for `Input` component
   - Major: Deprecate unused props API `Input`: `invalid`, `defaultValue`
+  - Minor: Add `setTabActiveStates` to `Tag` component ref API
+  - Patch: Use new `setTabActiveStates` in `TagList` component to set the correct active child when using keyboard nav
 </details>
 
 ## v0.49.0

--- a/src/components/tag-list/tag-list.jsx
+++ b/src/components/tag-list/tag-list.jsx
@@ -36,15 +36,19 @@ export default function TagList(props) {
       case 'ArrowLeft':
       case 'ArrowUp':
         if (activeIndex > 0) {
+          const newActiveIndex = activeIndex - 1;
           event.preventDefault();
-          setActiveIndex(activeIndex - 1);
+          setActiveIndex(newActiveIndex);
+          props.refs[newActiveIndex].current.setTabActiveStates([false, true]);
         }
         break;
       case 'ArrowRight':
       case 'ArrowDown':
         if (activeIndex < props.refs.length - 1) {
+          const newActiveIndex = activeIndex + 1;
           event.preventDefault();
-          setActiveIndex(activeIndex + 1);
+          setActiveIndex(newActiveIndex);
+          props.refs[newActiveIndex].current.setTabActiveStates([true, false]);
         }
         break;
       case 'End':

--- a/src/components/tag-list/tag-list.test.jsx
+++ b/src/components/tag-list/tag-list.test.jsx
@@ -106,6 +106,22 @@ describe('TagList', () => {
         fireEvent.keyDown(document.activeElement, { key: 'Home' });
         await waitFor(() => expect(screen.getByText('Test Child 1')).toHaveFocus());
       });
+
+      it('focuses the remove icon when navigating left to fresh tags', async () => {
+        const refs = [createRef(), createRef(), createRef()];
+        render((
+          <TagList {...requiredProps} refs={refs}>
+            <Tag id="test-tag-1" ref={refs[0]}>Test Child 1</Tag>
+            <Tag id="test-tag-2" ref={refs[1]}>Test Child 2</Tag>
+            <Tag id="test-tag-3" ref={refs[2]}>Test Child 3</Tag>
+          </TagList>
+        ));
+
+        userEvent.click(screen.getByText('Test Child 3'));
+
+        fireEvent.keyDown(document.activeElement, { key: 'ArrowLeft' });
+        await waitFor(() => expect(screen.getAllByRole('button')[1]).toHaveFocus());
+      });
     });
 
     describe('click focusing', () => {

--- a/src/components/tag/tag.jsx
+++ b/src/components/tag/tag.jsx
@@ -70,6 +70,11 @@ const Tag = forwardRef(function Tag(props, forwardedRef) {
   }, [focusQueued, isActive, ...tabActiveStates]);
 
   useImperativeHandle(ref, () => ({
+    setTabActiveStates: (array) => {
+      if (!props.readOnly) {
+        setTabActiveStates(array);
+      }
+    },
     setIsActive: (bool) => {
       setFocusQueued(bool);
       setIsActive(bool);

--- a/src/components/tag/tag.test.jsx
+++ b/src/components/tag/tag.test.jsx
@@ -163,4 +163,16 @@ describe('Tag', () => {
       await waitFor(() => expect(screen.getByText('Test Title')).toHaveFocus());
     });
   });
+
+  describe('setTabActiveStates ref API', () => {
+    it('sets tabActiveStates', async () => {
+      const ref = createRef();
+      render(<Tag {...requiredProps} ref={ref} />);
+
+      act(() => { ref.current.setTabActiveStates([false, true]); });
+      act(() => { ref.current.setIsActive(true); });
+
+      await waitFor(() => expect(screen.getByLabelText('Remove')).toEqual(document.activeElement));
+    });
+  });
 });


### PR DESCRIPTION
## Motivation
TagList items that have not yet been focused, when navigated to from the right, jump to their text content instead of their remove icon. This is a bug.

## Acceptance Criteria
- When clicking to focus a TagList item that is not the far left item, and is the first item focused
  - Navigating to an item to the left should focus the remove icon instead of the text content

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-taglist-nav-has-no-memory-of-this-place-173632521
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
