### PR TITLE
Deprecate `react-test-renderer` in test patterns

### DIFF
--- a/src/components/button/__snapshots__/button.test.jsx.snap
+++ b/src/components/button/__snapshots__/button.test.jsx.snap
@@ -1,10 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Button has defaults 1`] = `
-<button
-  className="primary"
-  onClick={[Function]}
->
-  Hello world!
-</button>
+<body>
+  <div>
+    <button
+      class="primary"
+    >
+      Hello world!
+    </button>
+  </div>
+</body>
 `;

--- a/src/components/button/button.test.jsx
+++ b/src/components/button/button.test.jsx
@@ -1,16 +1,15 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 import { fireEvent, render, screen } from '@testing-library/react';
 import Button from './button.jsx';
 
 describe('Button', () => {
   it('has defaults', () => {
-    const tree = renderer.create((
+    render((
       <Button>
         Hello world!
       </Button>
-    )).toJSON();
-    expect(tree).toMatchSnapshot();
+    ));
+    expect(document.body).toMatchSnapshot();
   });
 
   describe('className API', () => {

--- a/src/components/form-control/__snapshots__/form-control.test.jsx.snap
+++ b/src/components/form-control/__snapshots__/form-control.test.jsx.snap
@@ -1,22 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<FormControl> has defaults 1`] = `
-<div
-  onKeyDown={[Function]}
-  role="presentation"
->
-  <label
-    className="label"
-    htmlFor="test-id"
-  >
-    Test label
-  </label>
-  <div
-    className="control-container"
-  >
-    <input
-      id="test-id"
-    />
+<body>
+  <div>
+    <div
+      role="presentation"
+    >
+      <label
+        class="label"
+        for="test-id"
+      >
+        Test label
+      </label>
+      <div
+        class="control-container"
+      >
+        <input
+          id="test-id"
+        />
+      </div>
+    </div>
   </div>
-</div>
+</body>
 `;

--- a/src/components/form-control/form-control.test.jsx
+++ b/src/components/form-control/form-control.test.jsx
@@ -1,7 +1,6 @@
 import React, {
   createRef,
 } from 'react';
-import renderer from 'react-test-renderer';
 import {
   fireEvent,
   render,
@@ -17,7 +16,8 @@ describe('<FormControl>', () => {
   };
 
   it('has defaults', () => {
-    expect(renderer.create(<FormControl {...requiredProps} />).toJSON()).toMatchSnapshot();
+    render(<FormControl {...requiredProps} />);
+    expect(document.body).toMatchSnapshot();
   });
 
   it('requires either an id or a labelId', () => {

--- a/src/components/list-option/__snapshots__/list-option.test.jsx.snap
+++ b/src/components/list-option/__snapshots__/list-option.test.jsx.snap
@@ -1,14 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`src/components/list-option/list-option renders defaults 1`] = `
-<li
-  aria-selected={false}
-  className="option"
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  role="option"
-  tabIndex="0"
->
-  Test option
-</li>
+<body>
+  <div>
+    <li
+      aria-selected="false"
+      class="option"
+      role="option"
+      tabindex="0"
+    >
+      Test option
+    </li>
+  </div>
+</body>
 `;

--- a/src/components/list-option/list-option.test.jsx
+++ b/src/components/list-option/list-option.test.jsx
@@ -1,7 +1,6 @@
 import React, {
   createRef,
 } from 'react';
-import renderer from 'react-test-renderer';
 import {
   act,
   fireEvent,
@@ -18,8 +17,8 @@ describe('src/components/list-option/list-option', () => {
   };
 
   it('renders defaults', () => {
-    const tree = renderer.create(<ListOption {...requiredProps} />).toJSON();
-    expect(tree).toMatchSnapshot();
+    render(<ListOption {...requiredProps} />);
+    expect(document.body).toMatchSnapshot();
   });
 
   describe('children API', () => {

--- a/src/components/page-header/__snapshots__/page-header.test.jsx.snap
+++ b/src/components/page-header/__snapshots__/page-header.test.jsx.snap
@@ -1,13 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PageHeader has defaults 1`] = `
-<header
-  className="container"
->
-  <h1
-    className="heading"
-  >
-    Defaults
-  </h1>
-</header>
+<body>
+  <div>
+    <header
+      class="container"
+    >
+      <h1
+        class="heading"
+      >
+        Defaults
+      </h1>
+    </header>
+  </div>
+</body>
 `;

--- a/src/components/page-header/page-header.test.jsx
+++ b/src/components/page-header/page-header.test.jsx
@@ -1,15 +1,11 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 import { render, screen } from '@testing-library/react';
 import PageHeader from './page-header.jsx';
 
 describe('PageHeader', () => {
   it('has defaults', () => {
-    const tree = renderer
-      .create((
-        <PageHeader title="Defaults" />
-      )).toJSON();
-    expect(tree).toMatchSnapshot();
+    render(<PageHeader title="Defaults" />);
+    expect(document.body).toMatchSnapshot();
   });
 
   it('has a title', () => {

--- a/src/components/section-row/__snapshots__/section-row.test.jsx.snap
+++ b/src/components/section-row/__snapshots__/section-row.test.jsx.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Section Row renders a section-row component 1`] = `
-<div
-  className="section-row"
-/>
+<body>
+  <div>
+    <div
+      class="section-row"
+    />
+  </div>
+</body>
 `;

--- a/src/components/section-row/section-row.test.jsx
+++ b/src/components/section-row/section-row.test.jsx
@@ -1,15 +1,11 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 import { render, screen } from '@testing-library/react';
 import SectionRow from './section-row.jsx';
 
 describe('Section Row', () => {
   it('renders a section-row component', () => {
-    const tree = renderer
-      .create((
-        <SectionRow />
-      )).toJSON();
-    expect(tree).toMatchSnapshot();
+    render(<SectionRow />);
+    expect(document.body).toMatchSnapshot();
   });
 
   it('can have child elements', () => {

--- a/src/components/section/__snapshots__/section.test.jsx.snap
+++ b/src/components/section/__snapshots__/section.test.jsx.snap
@@ -1,13 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Section renders a section component 1`] = `
-<section
-  className="section"
->
-  <h2
-    className="subheading"
-  >
-    Test Title
-  </h2>
-</section>
+<body>
+  <div>
+    <section
+      class="section"
+    >
+      <h2
+        class="subheading"
+      >
+        Test Title
+      </h2>
+    </section>
+  </div>
+</body>
 `;

--- a/src/components/section/section.test.jsx
+++ b/src/components/section/section.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 import { render, screen } from '@testing-library/react';
 import Section from './section.jsx';
 
@@ -9,11 +8,8 @@ describe('Section', () => {
   };
 
   it('renders a section component', () => {
-    const tree = renderer
-      .create((
-        <Section title="Test Title" />
-      )).toJSON();
-    expect(tree).toMatchSnapshot();
+    render(<Section title="Test Title" />);
+    expect(document.body).toMatchSnapshot();
   });
 
   it('uses a title', () => {

--- a/src/components/table/__snapshots__/table.test.jsx.snap
+++ b/src/components/table/__snapshots__/table.test.jsx.snap
@@ -1,56 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`rendering 1`] = `
-<table
-  className="table"
->
-  <thead
-    className="head"
-  >
-    <tr>
-      <th
-        className="headerCell"
-      >
-        id
-      </th>
-      <th
-        className="headerCell"
-      >
-        name
-      </th>
-    </tr>
-  </thead>
-  <tbody
-    className="body"
-  >
-    <tr
-      className="row"
+<body>
+  <div>
+    <table
+      class="table"
     >
-      <td
-        className="cell"
+      <thead
+        class="head"
       >
-        1
-      </td>
-      <td
-        className="cell"
+        <tr>
+          <th
+            class="headerCell"
+          >
+            id
+          </th>
+          <th
+            class="headerCell"
+          >
+            name
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="body"
       >
-        Bob Ross
-      </td>
-    </tr>
-    <tr
-      className="row"
-    >
-      <td
-        className="cell"
-      >
-        2
-      </td>
-      <td
-        className="cell"
-      >
-        Bob Marley
-      </td>
-    </tr>
-  </tbody>
-</table>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            1
+          </td>
+          <td
+            class="cell"
+          >
+            Bob Ross
+          </td>
+        </tr>
+        <tr
+          class="row"
+        >
+          <td
+            class="cell"
+          >
+            2
+          </td>
+          <td
+            class="cell"
+          >
+            Bob Marley
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</body>
 `;

--- a/src/components/table/table.test.jsx
+++ b/src/components/table/table.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import {
   Table,
   TableHeader,
@@ -9,8 +9,8 @@ import {
   TableCell,
 } from './index.js';
 
-function render() {
-  return renderer.create(
+test('rendering', () => {
+  render((
     <Table>
       <TableHeader>
         <TableHeaderCell>id</TableHeaderCell>
@@ -26,11 +26,7 @@ function render() {
           <TableCell>Bob Marley</TableCell>
         </TableRow>
       </TableBody>
-    </Table>,
-  );
-}
-
-test('rendering', () => {
-  const tree = render();
-  expect(tree.toJSON()).toMatchSnapshot();
+    </Table>
+  ));
+  expect(document.body).toMatchSnapshot();
 });

--- a/src/components/tag-skill/__snapshots__/tag-skill.test.jsx.snap
+++ b/src/components/tag-skill/__snapshots__/tag-skill.test.jsx.snap
@@ -1,40 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TagSkill has default 1`] = `
-<div
-  className="read-only-tag"
-  id="test-id"
-  role="row"
->
-  <span
-    className="content"
-    id="test-id-content"
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    role="gridcell"
-    tabIndex="0"
-  >
-    <span
-      className="row"
+<body>
+  <div>
+    <div
+      class="read-only-tag"
+      id="test-id"
+      role="row"
     >
-      Egg
       <span
-        className="level"
+        class="content"
+        id="test-id-content"
+        role="gridcell"
+        tabindex="0"
       >
-        <svg
-          height={9}
-          role="img"
-          width={12}
+        <span
+          class="row"
         >
-          <title>
-            No level
-          </title>
-          <use
-            xlinkHref="#tick.svg"
-          />
-        </svg>
+          Egg
+          <span
+            class="level"
+          >
+            <svg
+              height="9"
+              role="img"
+              width="12"
+            >
+              <title>
+                No level
+              </title>
+              <use
+                xlink:href="#tick.svg"
+              />
+            </svg>
+          </span>
+        </span>
       </span>
-    </span>
-  </span>
-</div>
+    </div>
+  </div>
+</body>
 `;

--- a/src/components/tag-skill/tag-skill.test.jsx
+++ b/src/components/tag-skill/tag-skill.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 import { render, screen } from '@testing-library/react';
 import TagSkill from './tag-skill.jsx';
 
@@ -10,7 +9,8 @@ describe('TagSkill', () => {
   };
 
   it('has default', () => {
-    expect(renderer.create(<TagSkill {...requiredProps} />).toJSON()).toMatchSnapshot();
+    render(<TagSkill {...requiredProps} />)
+    expect(document.body).toMatchSnapshot();
   });
 
   describe('id API', () => {

--- a/src/components/tag-skill/tag-skill.test.jsx
+++ b/src/components/tag-skill/tag-skill.test.jsx
@@ -9,7 +9,7 @@ describe('TagSkill', () => {
   };
 
   it('has default', () => {
-    render(<TagSkill {...requiredProps} />)
+    render(<TagSkill {...requiredProps} />);
     expect(document.body).toMatchSnapshot();
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9373,9 +9373,9 @@ react-styleguidist@10:
     webpack-merge "^4.2.2"
 
 react-test-renderer@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.13.1.tgz#de25ea358d9012606de51e012d9742e7f0deabc1"
-  integrity sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.14.0.tgz#e98360087348e260c56d4fe2315e970480c228ae"
+  integrity sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==
   dependencies:
     object-assign "^4.1.1"
     prop-types "^15.6.2"


### PR DESCRIPTION
## Motivation

We want to stop using `react-test-renderer` as our snapshot generator. Instead, we should always use the `render` method from `@testing-library/react`. This ensures less overhead and actually tests any side effects on the DOM. 

## Acceptance Criteria

- Tests are still green

## PR upkeep checklist

- [ ] Change log entry N/A
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/deprecate-react-test-renderer/
- [x] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check N/A
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?) N/A
