### PR TITLE
Add Popover component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
+  - Minor: Add new `Popover` component
 </details>
 
 ## v0.52.2

--- a/src/components/popover/__snapshots__/popover.test.jsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.jsx.snap
@@ -5,3 +5,9 @@ exports[`Popover has defaults 1`] = `
   <div />
 </body>
 `;
+
+exports[`Popover has defaults 2`] = `
+Object {
+  "open": false,
+}
+`;

--- a/src/components/popover/__snapshots__/popover.test.jsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.jsx.snap
@@ -7,6 +7,48 @@ exports[`Popover has defaults 1`] = `
 `;
 
 exports[`Popover has defaults 2`] = `
+<body>
+  <div />
+  <div>
+    <section
+      aria-labelledby="popover-heading"
+      class="container"
+      role="dialog"
+    >
+      <div
+        role="presentation"
+      >
+        <div
+          class="heading-container"
+          id="popover-heading"
+        >
+          <h1
+            class="heading"
+          >
+            Defaults
+          </h1>
+          <svg
+            class="close-button"
+            height="8"
+            role="button"
+            tabindex="0"
+            width="8"
+          >
+            <title>
+              Close popover
+            </title>
+            <use
+              xlink:href="#clear.svg"
+            />
+          </svg>
+        </div>
+      </div>
+    </section>
+  </div>
+</body>
+`;
+
+exports[`Popover has defaults 3`] = `
 Object {
   "open": false,
 }

--- a/src/components/popover/__snapshots__/popover.test.jsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.jsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Popover has defaults 1`] = `
+<body>
+  <div />
+</body>
+`;

--- a/src/components/popover/popover.css
+++ b/src/components/popover/popover.css
@@ -16,7 +16,7 @@
   border: 1px solid var(--mds-grey-12);
   box-shadow: var(--spacing-small) var(--spacing-small) var(--spacing-small) var(--mds-grey-8);
   padding: var(--spacing-large);
-  position: fixed;
+  position: absolute;
   z-index: 10;
 }
 

--- a/src/components/popover/popover.css
+++ b/src/components/popover/popover.css
@@ -1,0 +1,32 @@
+@import '../../styles/colors-v2.css';
+@import '../../styles/spacing.css';
+@import '../../styles/typography-v2.css';
+
+.close-button {
+  composes: button from '../icon-button/icon-button.css';
+  height: 12px;
+  margin-left: var(--spacing-large);
+  padding: var(--spacing-small);
+  padding-top: 5px;
+  width: 12px;
+}
+
+.container {
+  background-color: var(--white);
+  border: 1px solid var(--mds-grey-12);
+  box-shadow: var(--spacing-small) var(--spacing-small) var(--spacing-small) var(--mds-grey-8);
+  padding: var(--spacing-large);
+  position: fixed;
+  z-index: 10;
+}
+
+.heading {
+  font: var(--mds-type-subhead-1);
+  margin-bottom: var(--spacing-large);
+  margin-top: 0;
+}
+
+.heading-container {
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/components/popover/popover.jsx
+++ b/src/components/popover/popover.jsx
@@ -18,7 +18,7 @@ const Popover = forwardRef(function Popover(props, ref) {
   const selfRef = ref || backupRef;
 
   const onFocusIn = (event) => {
-    if (open && event.target instanceof HTMLElement && !sectionRef.current.contains(event.target)) {
+    if (open && event.target instanceof Node && !sectionRef.current.contains(event.target)) {
       setOpen(false);
     }
   };

--- a/src/components/popover/popover.jsx
+++ b/src/components/popover/popover.jsx
@@ -14,7 +14,14 @@ const Popover = forwardRef(function Popover(props, ref) {
   const [open, setOpen] = useState(false);
   const closeIconRef = useRef();
   const backupRef = useRef();
+  const sectionRef = useRef();
   const selfRef = ref || backupRef;
+
+  const onFocusIn = (event) => {
+    if (open && event.target instanceof HTMLElement && !sectionRef.current.contains(event.target)) {
+      setOpen(false);
+    }
+  };
 
   const onWindowClick = () => {
     if (open) {
@@ -24,6 +31,7 @@ const Popover = forwardRef(function Popover(props, ref) {
 
   useEffect(() => {
     window.addEventListener('click', onWindowClick);
+    window.addEventListener('focusin', onFocusIn);
 
     if (closeIconRef.current && open) {
       closeIconRef.current.focus();
@@ -35,6 +43,7 @@ const Popover = forwardRef(function Popover(props, ref) {
 
     return () => {
       window.removeEventListener('click', onWindowClick);
+      window.removeEventListener('focusin', onFocusIn);
     };
   }, [open]);
 
@@ -57,6 +66,7 @@ const Popover = forwardRef(function Popover(props, ref) {
       aria-labelledby="popover-heading"
       className={styles.container}
       onClick={(event) => { event.stopPropagation(); }}
+      ref={sectionRef}
       role="dialog"
       style={{ left: `${props.left}px`, top: `${props.top}px` }}
     >

--- a/src/components/popover/popover.jsx
+++ b/src/components/popover/popover.jsx
@@ -1,0 +1,94 @@
+import PropTypes from 'prop-types';
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+import IconButton from '../icon-button/icon-button.jsx';
+import iconClear from '../../svgs/clear.svg';
+import styles from './popover.css';
+
+const Popover = forwardRef(function Popover(props, ref) {
+  const [open, setOpen] = useState(false);
+  const closeIconRef = useRef();
+  const backupRef = useRef();
+  const selfRef = ref || backupRef;
+
+  const onWindowClick = () => {
+    if (open) {
+      setOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('click', onWindowClick);
+
+    if (closeIconRef.current && open) {
+      closeIconRef.current.focus();
+    }
+
+    if (!open) {
+      props.onClose();
+    }
+
+    return () => {
+      window.removeEventListener('click', onWindowClick);
+    };
+  }, [open]);
+
+  useImperativeHandle(selfRef, () => ({
+    get open() {
+      return open;
+    },
+    set open(value) {
+      setOpen(value);
+    },
+  }));
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+    <section
+      aria-labelledby="popover-heading"
+      className={styles.container}
+      onClick={(event) => { event.stopPropagation(); }}
+      role="dialog"
+      style={{ left: `${props.left}px`, top: `${props.top}px` }}
+    >
+      <div className={styles['heading-container']} id="popover-heading">
+        <h1 className={styles.heading}>{props.title}</h1>
+        <IconButton
+          active={true}
+          className={styles['close-button']}
+          icon={iconClear}
+          label={'Close popover'}
+          onPress={() => { setOpen(false); }}
+          ref={closeIconRef}
+        />
+      </div>
+      {props.children}
+    </section>
+  );
+});
+
+Popover.propTypes = {
+  children: PropTypes.node,
+  left: PropTypes.number,
+  onClose: PropTypes.func,
+  title: PropTypes.string.isRequired,
+  top: PropTypes.number,
+};
+
+Popover.defaultProps = {
+  children: undefined,
+  left: undefined,
+  onClose: () => {},
+  top: undefined,
+};
+
+export default Popover;

--- a/src/components/popover/popover.jsx
+++ b/src/components/popover/popover.jsx
@@ -11,7 +11,7 @@ import iconClear from '../../svgs/clear.svg';
 import styles from './popover.css';
 
 const Popover = forwardRef(function Popover(props, ref) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(props.startOpen);
   const closeIconRef = useRef();
   const backupRef = useRef();
   const sectionRef = useRef();
@@ -88,12 +88,14 @@ const Popover = forwardRef(function Popover(props, ref) {
 Popover.propTypes = {
   children: PropTypes.node,
   onClose: PropTypes.func,
+  startOpen: PropTypes.bool,
   title: PropTypes.string.isRequired,
 };
 
 Popover.defaultProps = {
   children: undefined,
   onClose: () => {},
+  startOpen: false,
 };
 
 export default Popover;

--- a/src/components/popover/popover.jsx
+++ b/src/components/popover/popover.jsx
@@ -66,7 +66,6 @@ const Popover = forwardRef(function Popover(props, ref) {
       className={styles.container}
       ref={sectionRef}
       role="dialog"
-      style={{ left: `${props.left}px`, top: `${props.top}px` }}
     >
       <div onClick={(event) => { event.stopPropagation(); }} role="presentation">
         <div className={styles['heading-container']} id="popover-heading">
@@ -88,17 +87,13 @@ const Popover = forwardRef(function Popover(props, ref) {
 
 Popover.propTypes = {
   children: PropTypes.node,
-  left: PropTypes.number,
   onClose: PropTypes.func,
   title: PropTypes.string.isRequired,
-  top: PropTypes.number,
 };
 
 Popover.defaultProps = {
   children: undefined,
-  left: undefined,
   onClose: () => {},
-  top: undefined,
 };
 
 export default Popover;

--- a/src/components/popover/popover.jsx
+++ b/src/components/popover/popover.jsx
@@ -61,27 +61,27 @@ const Popover = forwardRef(function Popover(props, ref) {
   }
 
   return (
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <section
       aria-labelledby="popover-heading"
       className={styles.container}
-      onClick={(event) => { event.stopPropagation(); }}
       ref={sectionRef}
       role="dialog"
       style={{ left: `${props.left}px`, top: `${props.top}px` }}
     >
-      <div className={styles['heading-container']} id="popover-heading">
-        <h1 className={styles.heading}>{props.title}</h1>
-        <IconButton
-          active={true}
-          className={styles['close-button']}
-          icon={iconClear}
-          label={'Close popover'}
-          onPress={() => { setOpen(false); }}
-          ref={closeIconRef}
-        />
+      <div onClick={(event) => { event.stopPropagation(); }} role="presentation">
+        <div className={styles['heading-container']} id="popover-heading">
+          <h1 className={styles.heading}>{props.title}</h1>
+          <IconButton
+            active={true}
+            className={styles['close-button']}
+            icon={iconClear}
+            label={'Close popover'}
+            onPress={() => { setOpen(false); }}
+            ref={closeIconRef}
+          />
+        </div>
+        {props.children}
       </div>
-      {props.children}
     </section>
   );
 });

--- a/src/components/popover/popover.md
+++ b/src/components/popover/popover.md
@@ -1,0 +1,42 @@
+The `popover` component provides functionality somewhere between a modal and a toggletip. It doesn't interrupt flow like a modal would, but provides more than the purely informational function of a toggletip. It is a way to allow for greater branching functionality while staying in-flow.
+
+The `popover` component provides a ref for getting and setting the `open` state, as well as an `onClose` callback in props. These features can be used to more tightly control the open/close functionality, and to return focus to the correct element once closed.
+
+`popover`s will close if a `click` event reaches the root `window`, so click events that should not close the `popover` should have `stopPropogation` called on them.
+
+```js
+const popoverRef = React.createRef();
+
+const onButtonClicked = () => {
+  popoverRef.current.open = !popoverRef.current.open;
+}
+
+<React.Fragment>
+  <button onClick={onButtonClicked}>Toggle Popover</button>
+  <Popover ref={popoverRef} title="Popover Title" />
+</React.Fragment>
+```
+
+
+`popover` can be manually positioned relative to screenspace, and will maintain that position (doesn't scroll with page). Care should be taken to add `tabIndex` properties to interactive elements within the `popover` to properly support keyboard accessibility.
+
+```js
+import SectionRow from '../section-row/section-row.jsx';
+
+const popoverRef = React.createRef();
+
+const onButtonClicked = () => {
+  popoverRef.current.open = !popoverRef.current.open;
+}
+
+<React.Fragment>
+  <button onClick={onButtonClicked}>Toggle Popover</button>
+  <Popover ref={popoverRef} title="Popover Title" top={window.innerHeight / 2} left={window.innerWidth / 2}>
+    <button tabIndex={-1}>A test button</button>
+    <SectionRow>
+      <span>Some nested content</span>
+      <span>Some more nested content</span>
+    </SectionRow>
+  </Popover>
+</React.Fragment>
+```

--- a/src/components/popover/popover.md
+++ b/src/components/popover/popover.md
@@ -1,8 +1,8 @@
-The `popover` component provides functionality somewhere between a modal and a toggletip. It doesn't interrupt flow like a modal would, but provides more than the purely informational function of a toggletip. It is a way to allow for greater branching functionality while staying in-flow.
+The `Popover` component provides functionality somewhere between a modal and a toggletip. It doesn't interrupt flow like a modal would, but provides more than the purely informational function of a toggletip. It is a way to allow for greater branching functionality while staying in-flow.
 
-The `popover` component provides a ref for getting and setting the `open` state, as well as an `onClose` callback in props. These features can be used to more tightly control the open/close functionality, and to return focus to the correct element once closed.
+The `Popover` component provides a ref for getting and setting the `open` state, as well as an `onClose` callback in props. These features can be used to more tightly control the open/close functionality, and to return focus to the correct element once closed.
 
-`popover`s will close if a `click` event reaches the root `window`, so click events that should not close the `popover` should have `stopPropogation` called on them.
+`Popover`s will close if a `click` event reaches the root `window`, so click events that should not close the `Popover` should have `stopPropogation` called on them.
 
 ```js
 const popoverRef = React.createRef();
@@ -18,7 +18,7 @@ const onButtonClicked = () => {
 ```
 
 
-`popover` can be manually positioned relative to screenspace, and will maintain that position (doesn't scroll with page). Care should be taken to add `tabIndex` properties to interactive elements within the `popover` to properly support keyboard accessibility.
+`Popover` can be manually positioned relative to screenspace, and will maintain that position (doesn't scroll with page). Care should be taken to add `tabIndex` properties to interactive elements within the `Popover` to properly support keyboard accessibility.
 
 ```js
 import SectionRow from '../section-row/section-row.jsx';

--- a/src/components/popover/popover.md
+++ b/src/components/popover/popover.md
@@ -32,7 +32,7 @@ const onButtonClicked = () => {
 <React.Fragment>
   <button onClick={onButtonClicked}>Toggle Popover</button>
   <Popover ref={popoverRef} title="Popover Title" top={window.innerHeight / 2} left={window.innerWidth / 2}>
-    <button tabIndex={-1}>A test button</button>
+    <button tabIndex={0}>A test button</button>
     <SectionRow>
       <span>Some nested content</span>
       <span>Some more nested content</span>

--- a/src/components/popover/popover.md
+++ b/src/components/popover/popover.md
@@ -2,36 +2,46 @@ The `Popover` component provides functionality somewhere between a modal and a t
 
 The `Popover` component provides a ref for getting and setting the `open` state, as well as an `onClose` callback in props. These features can be used to more tightly control the open/close functionality, and to return focus to the correct element once closed.
 
-`Popover`s will close if a `click` event reaches the root `window`, so click events that should not close the `Popover` should have `stopPropogation` called on them.
+`Popover`s will close if a `click` or `focusin` event reaches the root `window` (the popover ignores these events if they originate from within it), so click/focus events that should not close the `Popover` should have `stopPropogation` called on them.
 
 ```js
 const popoverRef = React.createRef();
 
-const onButtonClicked = () => {
-  popoverRef.current.open = !popoverRef.current.open;
+const onButtonClicked = (event) => {
+  popoverRef.current.open = true;
+  event.stopPropagation();
+  // These are to prevent the popover from closing when we want to keep it open
+}
+
+const onButtonFocused = (event) => {
+  event.stopPropagation();
+  event.preventDefault();
+  // These are to prevent the popover from closing when we want to keep it open
+  // Unfortunately, for focus events, this only works in React>=17
+  // See: https://github.com/facebook/react/issues/6410
 }
 
 <React.Fragment>
-  <button onClick={onButtonClicked}>Toggle Popover</button>
+  <button onClick={onButtonClicked} onFocus={onButtonFocused}>Open Popover</button>
   <Popover ref={popoverRef} title="Popover Title" />
 </React.Fragment>
 ```
 
 
-`Popover` can be manually positioned relative to screenspace, and will maintain that position (doesn't scroll with page). Care should be taken to add `tabIndex` properties to interactive elements within the `Popover` to properly support keyboard accessibility.
+`Popover` contents should generally be a mix of informational and interactive components. Interactive components should be in the user focus flow, usually by making sure they have a `tabIndex={0}`.
 
 ```js
 import SectionRow from '../section-row/section-row.jsx';
 
 const popoverRef = React.createRef();
 
-const onButtonClicked = () => {
-  popoverRef.current.open = !popoverRef.current.open;
+const onPopoverOpenButtonClick = () => {
+  popoverRef.current.open = true;
 }
 
 <React.Fragment>
-  <button onClick={onButtonClicked}>Toggle Popover</button>
-  <Popover ref={popoverRef} title="Popover Title" top={window.innerHeight / 2} left={window.innerWidth / 2}>
+  <button onClick={onPopoverOpenButtonClick}>Open Popover</button>
+  <Popover ref={popoverRef} title="Popover Title">
     <button tabIndex={0}>A test button</button>
     <SectionRow>
       <span>Some nested content</span>

--- a/src/components/popover/popover.test.jsx
+++ b/src/components/popover/popover.test.jsx
@@ -41,14 +41,6 @@ describe('Popover', () => {
     expect(screen.getByText('More text'));
   });
 
-  it('sets left and top', () => {
-    render(<PopoverWithToggle title="Another title" left={100} top={200} />);
-
-    userEvent.click(screen.getByText('Open Popover'));
-    expect(screen.getByRole('dialog')).toHaveStyle('left: 100px');
-    expect(screen.getByRole('dialog')).toHaveStyle('top: 200px');
-  });
-
   it('can be toggled open/closed', () => {
     render(<PopoverWithToggle title="Another title" />);
 

--- a/src/components/popover/popover.test.jsx
+++ b/src/components/popover/popover.test.jsx
@@ -1,0 +1,96 @@
+import React, { useRef, Fragment } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Popover from './popover.jsx';
+
+describe('Popover', () => {
+  function PopoverWithToggle(popoverProps) {
+    const popoverRef = useRef();
+
+    return (
+      <Fragment>
+        <button onClick={() => { popoverRef.current.open = !popoverRef.current.open; }}>Toggle Popover</button>
+        <span>Some text</span>
+        <Popover ref={popoverRef} {...popoverProps}>{popoverProps.children}</Popover>
+      </Fragment>
+    );
+  }
+
+  it('has defaults', () => {
+    render(<Popover title="Defaults" />);
+    expect(document.body).toMatchSnapshot();
+  });
+
+  it('has a title', () => {
+    render(<PopoverWithToggle title="Another title" />);
+
+    userEvent.click(screen.getByText('Toggle Popover'));
+    expect(screen.getByText('Another title').tagName).toEqual('H1');
+  });
+
+  it('renders children', () => {
+    render(<PopoverWithToggle title="Another title"><span>More text</span></PopoverWithToggle>);
+
+    userEvent.click(screen.getByText('Toggle Popover'));
+    expect(screen.getByText('More text'));
+  });
+
+  it('sets left and top', () => {
+    render(<PopoverWithToggle title="Another title" left={100} top={200} />);
+
+    userEvent.click(screen.getByText('Toggle Popover'));
+    expect(screen.getByRole('dialog')).toHaveStyle('left: 100px');
+    expect(screen.getByRole('dialog')).toHaveStyle('top: 200px');
+  });
+
+  it('can be toggled open/closed', () => {
+    render(<PopoverWithToggle title="Another title" />);
+
+    userEvent.click(screen.getByText('Toggle Popover'));
+    expect(screen.getByText('Another title').tagName).toEqual('H1');
+
+    userEvent.click(screen.getByText('Toggle Popover'));
+    expect(screen.queryByText('Another title')).toEqual(null);
+  });
+
+  it('can be closed by clicking elsewhere in the window', () => {
+    render(<PopoverWithToggle title="Another title" />);
+
+    userEvent.click(screen.getByText('Toggle Popover'));
+    expect(screen.getByText('Another title').tagName).toEqual('H1');
+
+    userEvent.click(screen.getByText('Some text'));
+    expect(screen.queryByText('Another title')).toEqual(null);
+  });
+
+  it('opens with focus on the close iconbutton', () => {
+    render(<PopoverWithToggle title="Another title" />);
+
+    userEvent.click(screen.getByText('Toggle Popover'));
+    expect(document.activeElement.tagName).toEqual('svg');
+  });
+
+  it('can be closed by activating the close iconbutton', () => {
+    render(<PopoverWithToggle title="Another title" />);
+
+    userEvent.click(screen.getByText('Toggle Popover'));
+    userEvent.click(document.activeElement);
+    expect(screen.queryByText('Another title')).toEqual(null);
+
+    userEvent.click(screen.getByText('Toggle Popover'));
+    fireEvent.keyDown(document.activeElement, { key: 'Spacebar' });
+    expect(screen.queryByText('Another title')).toEqual(null);
+
+    userEvent.click(screen.getByText('Toggle Popover'));
+    fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+    expect(screen.queryByText('Another title')).toEqual(null);
+  });
+
+  it('does not close when clicking within itself', () => {
+    render(<PopoverWithToggle title="Another title"><span>More text</span></PopoverWithToggle>);
+
+    userEvent.click(screen.getByText('Toggle Popover'));
+    userEvent.click(screen.getByText('More text'));
+    expect(screen.getByText('Another title').tagName).toEqual('H1');
+  });
+});

--- a/src/components/popover/popover.test.jsx
+++ b/src/components/popover/popover.test.jsx
@@ -45,37 +45,36 @@ describe('Popover', () => {
     render(<PopoverWithToggle title="Another title" />);
 
     userEvent.click(screen.getByText('Open Popover'));
-    expect(screen.getByText('Another title').tagName).toEqual('H1');
+    expect(screen.getByText('Another title')).toBeInTheDocument();
 
     userEvent.click(screen.getByText('Close Popover'));
-    expect(screen.queryByText('Another title')).toEqual(null);
+    expect(screen.queryByText('Another title')).not.toBeInTheDocument();
   });
 
   it('can be closed by clicking elsewhere in the window', () => {
     render(<PopoverWithToggle title="Another title" />);
 
     userEvent.click(screen.getByText('Open Popover'));
-    expect(screen.getByText('Another title').tagName).toEqual('H1');
+    expect(screen.getByText('Another title')).toBeInTheDocument();
 
     userEvent.click(screen.getByText('Some text'));
-    expect(screen.queryByText('Another title')).toEqual(null);
+    expect(screen.queryByText('Another title')).not.toBeInTheDocument();
   });
 
   it('can be closed by focusing outside', () => {
     render(<PopoverWithToggle title="Another title" />);
 
     userEvent.click(screen.getByText('Open Popover'));
-    expect(screen.getByText('Another title').tagName).toEqual('H1');
 
     fireEvent.focusIn(screen.getByText('Close Popover'));
-    expect(screen.queryByText('Another title')).toEqual(null);
+    expect(screen.queryByText('Another title')).not.toBeInTheDocument();
   });
 
   it('opens with focus on the close iconbutton', () => {
     render(<PopoverWithToggle title="Another title" />);
 
     userEvent.click(screen.getByText('Open Popover'));
-    expect(document.activeElement.tagName).toEqual('svg');
+    expect(document.activeElement).toContainElement(screen.getByTitle('Close popover'));
   });
 
   it('can be closed by activating the close iconbutton', () => {

--- a/src/components/popover/popover.test.jsx
+++ b/src/components/popover/popover.test.jsx
@@ -18,8 +18,13 @@ describe('Popover', () => {
   }
 
   it('has defaults', () => {
+    const popoverRef = React.createRef();
+
     render(<Popover title="Defaults" />);
     expect(document.body).toMatchSnapshot();
+
+    render(<Popover ref={popoverRef} title="Defaults with ref" />);
+    expect(popoverRef.current).toMatchSnapshot();
   });
 
   it('has a title', () => {

--- a/src/components/popover/popover.test.jsx
+++ b/src/components/popover/popover.test.jsx
@@ -9,7 +9,8 @@ describe('Popover', () => {
 
     return (
       <Fragment>
-        <button onClick={() => { popoverRef.current.open = !popoverRef.current.open; }}>Toggle Popover</button>
+        <button onClick={() => { popoverRef.current.open = true; }}>Open Popover</button>
+        <button onClick={() => { popoverRef.current.open = false; }}>Close Popover</button>
         <span>Some text</span>
         <Popover ref={popoverRef} {...popoverProps}>{popoverProps.children}</Popover>
       </Fragment>
@@ -24,21 +25,21 @@ describe('Popover', () => {
   it('has a title', () => {
     render(<PopoverWithToggle title="Another title" />);
 
-    userEvent.click(screen.getByText('Toggle Popover'));
+    userEvent.click(screen.getByText('Open Popover'));
     expect(screen.getByText('Another title').tagName).toEqual('H1');
   });
 
   it('renders children', () => {
     render(<PopoverWithToggle title="Another title"><span>More text</span></PopoverWithToggle>);
 
-    userEvent.click(screen.getByText('Toggle Popover'));
+    userEvent.click(screen.getByText('Open Popover'));
     expect(screen.getByText('More text'));
   });
 
   it('sets left and top', () => {
     render(<PopoverWithToggle title="Another title" left={100} top={200} />);
 
-    userEvent.click(screen.getByText('Toggle Popover'));
+    userEvent.click(screen.getByText('Open Popover'));
     expect(screen.getByRole('dialog')).toHaveStyle('left: 100px');
     expect(screen.getByRole('dialog')).toHaveStyle('top: 200px');
   });
@@ -46,42 +47,52 @@ describe('Popover', () => {
   it('can be toggled open/closed', () => {
     render(<PopoverWithToggle title="Another title" />);
 
-    userEvent.click(screen.getByText('Toggle Popover'));
+    userEvent.click(screen.getByText('Open Popover'));
     expect(screen.getByText('Another title').tagName).toEqual('H1');
 
-    userEvent.click(screen.getByText('Toggle Popover'));
+    userEvent.click(screen.getByText('Close Popover'));
     expect(screen.queryByText('Another title')).toEqual(null);
   });
 
   it('can be closed by clicking elsewhere in the window', () => {
     render(<PopoverWithToggle title="Another title" />);
 
-    userEvent.click(screen.getByText('Toggle Popover'));
+    userEvent.click(screen.getByText('Open Popover'));
     expect(screen.getByText('Another title').tagName).toEqual('H1');
 
     userEvent.click(screen.getByText('Some text'));
     expect(screen.queryByText('Another title')).toEqual(null);
   });
 
+  it('can be closed by focusing outside', () => {
+    render(<PopoverWithToggle title="Another title" />);
+
+    userEvent.click(screen.getByText('Open Popover'));
+    expect(screen.getByText('Another title').tagName).toEqual('H1');
+
+    fireEvent.focusIn(screen.getByText('Close Popover'));
+    expect(screen.queryByText('Another title')).toEqual(null);
+  });
+
   it('opens with focus on the close iconbutton', () => {
     render(<PopoverWithToggle title="Another title" />);
 
-    userEvent.click(screen.getByText('Toggle Popover'));
+    userEvent.click(screen.getByText('Open Popover'));
     expect(document.activeElement.tagName).toEqual('svg');
   });
 
   it('can be closed by activating the close iconbutton', () => {
     render(<PopoverWithToggle title="Another title" />);
 
-    userEvent.click(screen.getByText('Toggle Popover'));
+    userEvent.click(screen.getByText('Open Popover'));
     userEvent.click(document.activeElement);
     expect(screen.queryByText('Another title')).toEqual(null);
 
-    userEvent.click(screen.getByText('Toggle Popover'));
+    userEvent.click(screen.getByText('Open Popover'));
     fireEvent.keyDown(document.activeElement, { key: 'Spacebar' });
     expect(screen.queryByText('Another title')).toEqual(null);
 
-    userEvent.click(screen.getByText('Toggle Popover'));
+    userEvent.click(screen.getByText('Open Popover'));
     fireEvent.keyDown(document.activeElement, { key: 'Enter' });
     expect(screen.queryByText('Another title')).toEqual(null);
   });
@@ -89,7 +100,7 @@ describe('Popover', () => {
   it('does not close when clicking within itself', () => {
     render(<PopoverWithToggle title="Another title"><span>More text</span></PopoverWithToggle>);
 
-    userEvent.click(screen.getByText('Toggle Popover'));
+    userEvent.click(screen.getByText('Open Popover'));
     userEvent.click(screen.getByText('More text'));
     expect(screen.getByText('Another title').tagName).toEqual('H1');
   });

--- a/src/components/popover/popover.test.jsx
+++ b/src/components/popover/popover.test.jsx
@@ -23,6 +23,9 @@ describe('Popover', () => {
     render(<Popover title="Defaults" />);
     expect(document.body).toMatchSnapshot();
 
+    render(<Popover title="Defaults" startOpen={true} />);
+    expect(document.body).toMatchSnapshot();
+
     render(<Popover ref={popoverRef} title="Defaults with ref" />);
     expect(popoverRef.current).toMatchSnapshot();
   });

--- a/src/components/popover/popover.test.jsx
+++ b/src/components/popover/popover.test.jsx
@@ -34,7 +34,7 @@ describe('Popover', () => {
     render(<PopoverWithToggle title="Another title" />);
 
     userEvent.click(screen.getByText('Open Popover'));
-    expect(screen.getByText('Another title').tagName).toEqual('H1');
+    expect(screen.getByRole('dialog', { name: 'Another title' })).toBeInTheDocument();
   });
 
   it('renders children', () => {
@@ -69,7 +69,9 @@ describe('Popover', () => {
 
     userEvent.click(screen.getByText('Open Popover'));
 
-    fireEvent.focusIn(screen.getByText('Close Popover'));
+    userEvent.tab();
+    userEvent.tab();
+    expect(screen.getByText('Open Popover')).toHaveFocus();
     expect(screen.queryByText('Another title')).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Motivation
We need a popover component for the form builder in order for a user to configure an individual component in the canvas. This component should be in the design system so that other teams can utilize it as well.

## Acceptance Criteria
SEE DRD:
https://docs.google.com/document/d/1JpQFBPt0Z6XF8xjjHco5qH8ubb3t2A4H_kwT_oEQE5I/edit?usp=sharing

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-all-about-the-popover-175407314/#/Components/Popover
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
