### PR TITLE
Webinf do you really need a section title 176100654

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
+  - Patch: Make `title` prop no longer required for `Section`
 </details>
 
 ## v0.53.1

--- a/src/components/section/__snapshots__/section.test.jsx.snap
+++ b/src/components/section/__snapshots__/section.test.jsx.snap
@@ -5,13 +5,7 @@ exports[`Section renders a section component 1`] = `
   <div>
     <section
       class="section"
-    >
-      <h2
-        class="subheading"
-      >
-        Test Title
-      </h2>
-    </section>
+    />
   </div>
 </body>
 `;

--- a/src/components/section/section.jsx
+++ b/src/components/section/section.jsx
@@ -5,7 +5,9 @@ import styles from './section.css';
 export default function Section(props) {
   return (
     <section className={styles.section}>
-      <h2 className={styles.subheading}>{props.title}</h2>
+      {props.title &&
+        <h2 className={styles.subheading}>{props.title}</h2>
+      }
       {props.description && <p className={styles.description}>{props.description}</p>}
       {props.children}
     </section>
@@ -15,10 +17,11 @@ export default function Section(props) {
 Section.propTypes = {
   children: PropTypes.node,
   description: PropTypes.string,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
 };
 
 Section.defaultProps = {
   children: undefined,
   description: undefined,
+  title: undefined,
 };

--- a/src/components/section/section.md
+++ b/src/components/section/section.md
@@ -1,4 +1,4 @@
-`Section`s can be used to semantically group controls, information, and inputs. `Section`s get the `region` ARIA role by default, and the `title` prop is required to support accessibility with a contained heading. For now, the `Section` component should only be used in Custom Apps, while the "page layout" spec is still in flux.
+`Section`s can be used to semantically group controls, information, and inputs. `Section`s get the `region` ARIA role by default, and the `title` prop is needed to support accessibility with a contained heading (though `title` is not required, to support accessibility-agnostic use-cases). For now, the `Section` component should only be used in Custom Apps, while the "page layout" spec is still in flux.
 
 For rows that should contain more than one full-length component, a `SectionRow` should be used to wrap thse children.
 

--- a/src/components/section/section.test.jsx
+++ b/src/components/section/section.test.jsx
@@ -3,27 +3,23 @@ import { render, screen } from '@testing-library/react';
 import Section from './section.jsx';
 
 describe('Section', () => {
-  const requiredProps = {
-    title: 'Test Title',
-  };
-
   it('renders a section component', () => {
-    render(<Section title="Test Title" />);
+    render(<Section />);
     expect(document.body).toMatchSnapshot();
   });
 
-  it('uses a title', () => {
-    render(<Section {...requiredProps} />);
+  it('can have a title', () => {
+    render(<Section title="Test Title" />);
     expect(screen.getByText('Test Title').tagName).toEqual('H2');
   });
 
   it('can have a description', () => {
-    render(<Section {...requiredProps} description="This is a test description." />);
+    render(<Section description="This is a test description." />);
     expect(screen.getByText('This is a test description.').tagName).toEqual('P');
   });
 
   it('can have child elements', () => {
-    render(<Section {...requiredProps} ><span>Test Label</span></Section>);
+    render(<Section><span>Test Label</span></Section>);
     expect(screen.getByText('Test Label').tagName).toEqual('SPAN');
   });
 });


### PR DESCRIPTION
## Motivation
We do not want a hard-coded "Section title" in the custom form

## Acceptance Criteria
- Section component does not require title

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-do-you-really-need-a-section-title-176100654/#/Components/Section
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check
- [x] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
