### PR TITLE
`undefined` coerces to `null` to avoid browser warnings when clearing…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
   - Append new items to make git merging easier.
 </details>
 
-## v0.60.0
-  - Minor: `undefined` coerces to `null` to avoid browser warnings when clearing Number component's input 
+## v0.59.1
+  - Patch: `undefined` coerces to `null` to avoid browser warnings when clearing Number component's input 
 
 ## v0.59.0
   - Major: `ref.value` for CustomFieldInputNumber now returns its type as Integer. To upgrade replace value with String(value)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   - Append new items to make git merging easier.
 </details>
 
+## v0.60.0
+  - Minor: `undefined` coerces to `null` to avoid browser warnings when clearing Number component's input 
+
 ## v0.59.0
   - Major: `ref.value` for CustomFieldInputNumber now returns its type as Integer. To upgrade replace value with String(value)
 

--- a/src/components/number/number.jsx
+++ b/src/components/number/number.jsx
@@ -28,7 +28,11 @@ const Number = React.forwardRef((props, ref) => {
     // The MDS Number is using an uncontrolled `<input>`.
     // In order to set a new provided value prop, we
     // set the internal state of the `<input>`.
-    inputRef.current.value = props.value;
+    if (props.value === undefined) {
+      inputRef.current.value = null;
+    } else {
+      inputRef.current.value = props.value;
+    }
   }, [props.value]);
 
   function onBlur(event) {


### PR DESCRIPTION
… Number component's input

<!--
In order to reduce overhead in maintaining PRs, please follow these rules:
1. If there is a pivotal story, replace the motivation+AC sections and add the pivotal story URL
2. If there is no pivotal story, fill in the motivation and AC sections
3. Complete the PR checklist
-->


## Motivation
The browser was warning when we were clearing the input. It does not like it when we set `current.value` to `undefined`

## Acceptance Criteria


## PR upkeep checklist

- [ ] Change log entry
- [ ] Label(s)
- [ ] Assignee(s)
- [ ] Deployment URL: https://mavenlink.github.io/design-system/$BRANCH/
- [ ] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
