### PR TITLE
Webinf single choice loading 176989566

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
+  - Minor: Make `CustomFieldInputSingleChoice` use the `Loader` component while loading, placed inside the choices dropdown
+  - Major: Move `CustomFieldInputSingleChoice` mock handlers to function format to support delay
 </details>
 
 ## v0.61.0

--- a/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
+++ b/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
@@ -53,9 +53,6 @@ exports[`src/components/custom-field-input-single-choice/custom-field-input-sing
         </div>
       </div>
     </div>
-    <span>
-      Loading...
-    </span>
   </div>
 </body>
 `;

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -8,8 +8,9 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import useFetch from '@bloodyaugust/use-fetch';
-import Select from '../select/select.jsx';
 import ListOption from '../list-option/list-option.jsx';
+import Loader from '../loader/loader.jsx';
+import Select from '../select/select.jsx';
 import mockConstants from '../../mocks/mock-constants.js';
 
 const { API_ROOT } = mockConstants;
@@ -109,11 +110,11 @@ const CustomFieldInputSingleChoice = forwardRef(function CustomFieldInputSingleC
         required={props.required}
         value={value[0] !== -1 ? choices.find(choice => choice.id === value[0]) : undefined}
       >
-        { listOptions() }
+        {choices.length === 0
+          ? <Loader inline />
+          : listOptions()
+        }
       </Select>
-      {choices.length === 0 &&
-        <span>Loading...</span>
-      }
     </React.Fragment>
   );
 });

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.md
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.md
@@ -1,5 +1,6 @@
 The `CustomFieldInputSingleChoice` component represents the UI for a custom field of type single choice from Mavenlink's API.
 
+The examples on this page have a 5 second delay in loading their choices, to show their loading states.
 ### Default examples
 
 ```js

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
@@ -9,14 +9,14 @@ import CustomFieldInputSingleChoice from './custom-field-input-single-choice.jsx
 import mockHandlers from './mock-handlers.js';
 import {
   clearChoice,
-  openChoices,
+  getSingleChoiceRootByName,
   selectChoice,
   waitForChoices,
 } from './test-queries.js';
 
 describe('src/components/custom-field-input-single-choice/custom-field-input-single-choice', () => {
   beforeEach(() => {
-    jestServer.use(...mockHandlers);
+    jestServer.use(...mockHandlers());
   });
 
   const requiredProps = {
@@ -44,7 +44,7 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
     it('uses the set customFieldID to fetch choices', async () => {
       render(<CustomFieldInputSingleChoice {...requiredProps} customFieldID={'1'} />);
 
-      await waitForChoices();
+      await waitForChoices('Test label');
       selectChoice('Test label', 'Fizz');
     });
   });
@@ -122,17 +122,16 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
       const value = ['0'];
       render(<CustomFieldInputSingleChoice {...requiredProps} value={value} />);
 
-      await waitForChoices();
+      await waitForChoices('Test label');
 
-      expect(screen.getByLabelText('Test label')).toHaveValue('Foo');
+      expect(getSingleChoiceRootByName('Test label')).toHaveValue('Foo');
     });
 
     it('provided value sets the corresponding list item as selected', async () => {
       const value = ['0'];
       render(<CustomFieldInputSingleChoice {...requiredProps} value={value} />);
 
-      await waitForChoices();
-      openChoices('Test label');
+      await waitForChoices('Test label');
 
       expect(screen.getByText('Foo')).toHaveAttribute('aria-selected', 'true');
     });
@@ -143,11 +142,11 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
         value={['0']}
       />);
 
-      await waitForChoices();
+      await waitForChoices('Test label');
 
       rerender(<CustomFieldInputSingleChoice {...requiredProps} value={['1']} />);
 
-      expect(screen.getByLabelText('Test label')).toHaveValue('Bar');
+      expect(getSingleChoiceRootByName('Test label')).toHaveValue('Bar');
     });
 
     it('handles empty array without errors', async () => {
@@ -156,11 +155,11 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
         value={['0']}
       />);
 
-      await waitForChoices();
+      await waitForChoices('Test label');
 
       rerender(<CustomFieldInputSingleChoice {...requiredProps} value={[]} />);
 
-      expect(screen.getByLabelText('Test label')).toHaveValue('');
+      expect(getSingleChoiceRootByName('Test label')).toHaveValue('');
     });
   });
 
@@ -169,7 +168,7 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
       const inputRef = createRef(null);
       render(<CustomFieldInputSingleChoice {...requiredProps} value={['0']} ref={inputRef} />);
 
-      await waitForChoices();
+      await waitForChoices('Test label');
 
       expect(inputRef.current.value).toStrictEqual(['0']);
     });
@@ -184,7 +183,7 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
 
       render(<CustomFieldInputSingleChoice {...requiredProps} label="Oh La Mort" id="hey" onChange={onChange} />);
 
-      await waitForChoices();
+      await waitForChoices('Oh La Mort');
       selectChoice('Oh La Mort', 'Bar');
 
       expect(changeValue).toStrictEqual(['1']);
@@ -201,7 +200,7 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
     it('fetches choices on mount', async () => {
       render(<CustomFieldInputSingleChoice {...requiredProps} />);
 
-      await waitForChoices();
+      await waitForChoices('Test label');
       selectChoice('Test label', 'Foo');
     });
   });

--- a/src/components/custom-field-input-single-choice/mock-handlers.js
+++ b/src/components/custom-field-input-single-choice/mock-handlers.js
@@ -21,41 +21,42 @@ const choices = [
   },
 ];
 
-const handlers = [
-  rest.get(`${API_ROOT}/custom_field_choices`, (request, response, context) => {
-    const customFieldID = request.url.searchParams.get('for_custom_fields');
-    const matchingChoices = choices.filter((choice) => {
-      return choice.custom_field_id === customFieldID;
-    });
-    const customFieldChoices = {};
+export default function handlers(delay = 0) {
+  return [
+    rest.get(`${API_ROOT}/custom_field_choices`, (request, response, context) => {
+      const customFieldID = request.url.searchParams.get('for_custom_fields');
+      const matchingChoices = choices.filter((choice) => {
+        return choice.custom_field_id === customFieldID;
+      });
+      const customFieldChoices = {};
 
-    matchingChoices.forEach((choice) => {
-      customFieldChoices[choice.id] = {
-        custom_field_id: choice.custom_field_id,
-        label: choice.label,
-      };
-    });
+      matchingChoices.forEach((choice) => {
+        customFieldChoices[choice.id] = {
+          custom_field_id: choice.custom_field_id,
+          label: choice.label,
+        };
+      });
 
-    return response(
-      context.status(200),
-      context.json({
-        count: 2,
-        meta: {
+      return response(
+        context.status(200),
+        context.json({
           count: 2,
-          page_count: 1,
-          page_number: 0,
-          page_size: 2,
-        },
-        results: matchingChoices.map((choice) => {
-          return {
-            key: 'custom_field_choices',
-            id: choice.id,
-          };
+          meta: {
+            count: 2,
+            page_count: 1,
+            page_number: 0,
+            page_size: 2,
+          },
+          results: matchingChoices.map((choice) => {
+            return {
+              key: 'custom_field_choices',
+              id: choice.id,
+            };
+          }),
+          custom_field_choices: customFieldChoices,
         }),
-        custom_field_choices: customFieldChoices,
-      }),
-    );
-  }),
-];
-
-export default handlers;
+        context.delay(delay),
+      );
+    }),
+  ];
+}

--- a/src/components/custom-field-input-single-choice/test-queries.js
+++ b/src/components/custom-field-input-single-choice/test-queries.js
@@ -8,8 +8,12 @@ export function clearChoice() {
   userEvent.click(screen.getByText('Remove selected choice'));
 }
 
-export function openChoices(fieldLabel) {
-  userEvent.click(screen.getByLabelText(fieldLabel));
+export function getSingleChoiceRootByName(fieldName) {
+  return screen.getByRole('combobox', { name: fieldName });
+}
+
+export function openChoices(fieldName) {
+  userEvent.click(screen.getByRole('combobox', { name: fieldName }));
 }
 
 export function selectChoice(fieldLabel, choiceText) {
@@ -18,6 +22,7 @@ export function selectChoice(fieldLabel, choiceText) {
   userEvent.click(screen.getByText(choiceText));
 }
 
-export async function waitForChoices() {
-  await waitForElementToBeRemoved(() => screen.queryAllByText('Loading...'));
+export async function waitForChoices(fieldName) {
+  openChoices(fieldName);
+  await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 }

--- a/styleguide/utils/include-msw.js
+++ b/styleguide/utils/include-msw.js
@@ -2,7 +2,7 @@ import { setupWorker } from 'msw';
 import listHandlers from '../../src/components/list-option/mock-handlers.js';
 import customFieldSingleHandlers from '../../src/components/custom-field-input-single-choice/mock-handlers.js';
 
-setupWorker(...listHandlers, ...customFieldSingleHandlers).start({
+setupWorker(...listHandlers, ...customFieldSingleHandlers(5000)).start({
   serviceWorker: {
     url: `${window.location.pathname}mockServiceWorker.js`,
   },


### PR DESCRIPTION
## Motivation
Show the user that choices are still loading, and in a way that matches our design goals.

## Acceptance Criteria
- While a single choice field is loading:
  - Has a loading indicator in the dropdown
  - Loading indicator is focusable (can be clicked, does not change value of input)
  - The field is clickable / focusable
  - The field value is not cleared
- After the single choice field is fully loaded:
  - The loading indicator goes away
  - The real value (if any) is populated in the input
  - The dropdown has a list of choice

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-single-choice-loading-176989566/
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check
- [x] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
