### PR TITLE
feat(CustomFieldInputMultipleChoice): add self-loading of choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   - Append new items to make git merging easier.
 </details>
 
+## v0.63.0
+- feat(CustomFieldInputMultipleChoice): add self-loading of choices with customFieldID prop
+- BREAKING CHANGE(CustomFieldMultipleChoice): removed choices from the props API
+- patch(CustomFieldInput*Choice): fix mock handlers and unnecessary data munging
+- patch(MSW): Fix mock handlers format for custom field choices
 ## v0.62.1
 - Patch: Ensure MDS inputs use MDS fonts
 - Patch: Ensure MDS inputs have a height of 32px

--- a/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.jsx
+++ b/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.jsx
@@ -200,14 +200,9 @@ const CustomFieldInputMultipleChoice = forwardRef(function CustomFieldInputMulti
       await execute(`${API_ROOT}/custom_field_choices?for_custom_fields=${props.customFieldID}`)
         .then(({ json, mounted: isMounted }) => {
           if (isMounted) {
-            const mungedChoices = json.results.map((result) => {
-              return {
-                ...json[result.key][result.id],
-                id: result.id,
-              };
-            });
+            const choiceObjects = json.results.map(result => json[result.key][result.id]);
 
-            setChoices(mungedChoices);
+            setChoices(choiceObjects);
           }
         })
         .catch((error) => {

--- a/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.jsx
+++ b/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.jsx
@@ -8,6 +8,7 @@ import React, {
   forwardRef,
 } from 'react';
 import PropTypes from 'prop-types';
+import useFetch from '@bloodyaugust/use-fetch';
 import FormControl from '../form-control/form-control.jsx';
 import Icon from '../icon/icon.jsx';
 import IconButton from '../icon-button/icon-button.jsx';
@@ -17,6 +18,7 @@ import iconCaution from '../../svgs/caution.svg';
 import iconClear from '../../svgs/clear.svg';
 import Listbox from '../listbox/listbox.jsx';
 import ListOption from '../list-option/list-option.jsx';
+import Loader from '../loader/loader.jsx';
 import TagList from '../tag-list/tag-list.jsx';
 import Tag from '../tag/tag.jsx';
 import NoOptions from '../no-options/no-options.jsx';
@@ -24,6 +26,9 @@ import styles from './custom-field-input-multiple-choice.css';
 import useDropdownClose from '../../hooks/use-dropdown-close.js';
 import useMounted from '../../hooks/use-mounted.js';
 import useValidation from '../../hooks/use-validation.jsx';
+import mockConstants from '../../mocks/mock-constants.js';
+
+const { API_ROOT } = mockConstants;
 
 function getClassName(className, readOnly, errorText) {
   if (className) return className;
@@ -36,6 +41,7 @@ function getClassName(className, readOnly, errorText) {
 const CustomFieldInputMultipleChoice = forwardRef(function CustomFieldInputMultipleChoice(props, ref) {
   const autocompleteRef = useRef();
   const [autocompleteValue, setAutocompleteValue] = useState('');
+  const [choices, setChoices] = useState([]);
   const [expanded, setExpanded] = useState(false);
   const [value, setValue] = useState(props.value);
   const [validationMessage, validate] = useValidation(props.errorText, autocompleteRef);
@@ -54,6 +60,7 @@ const CustomFieldInputMultipleChoice = forwardRef(function CustomFieldInputMulti
   };
   const mounted = useMounted();
   const wrapperRef = useRef(null);
+  const { completed, execute } = useFetch();
 
   const handleDropdownClose = () => {
     setExpanded(false);
@@ -61,10 +68,53 @@ const CustomFieldInputMultipleChoice = forwardRef(function CustomFieldInputMulti
   };
   useDropdownClose(wrapperRef, expanded, handleDropdownClose);
 
+  const dropdownContents = () => {
+    if (!expanded) {
+      return undefined;
+    }
+
+    if (!completed) {
+      return (
+        <Listbox
+          className={styles['popup-container']}
+          id={ids.listbox}
+          labelledBy={ids.label}
+          refs={[]}
+        >
+          <Loader inline />
+        </Listbox>
+      );
+    }
+
+    if (visibleChoices.length === 0) {
+      return (<NoOptions className={styles['no-options']} id={ids.emptyMessage} />);
+    }
+
+    return (
+      <Listbox
+        className={styles['popup-container']}
+        id={ids.listbox}
+        labelledBy={ids.label}
+        refs={choicesRefs}
+      >
+        {visibleChoices.map((choice, index) => (
+          <ListOption
+            key={`${props.id}-${choice.id}`}
+            onSelect={onChoiceSelect}
+            ref={choicesRefs[index]}
+            value={choice.id}
+          >
+            {choice.label}
+          </ListOption>
+        ))}
+      </Listbox>
+    );
+  };
+
   function getVisibleChoices() {
-    return props.choices
+    return choices
       .filter(choice => choice.label.includes(autocompleteValue))
-      .filter(choice => !value.some(val => val.id === choice.id));
+      .filter(choice => !value.some(val => val === choice.id));
   }
 
   function onChoiceRemove(event) {
@@ -78,7 +128,7 @@ const CustomFieldInputMultipleChoice = forwardRef(function CustomFieldInputMulti
     const selectedChoiceIndex = choicesRefs.findIndex(choiceRef => choiceRef === event.target);
     const selectedChoice = visibleChoices[selectedChoiceIndex];
     setExpanded(false);
-    const newValue = [...value, selectedChoice].sort((a, b) => a.id - b.id);
+    const newValue = [...value, selectedChoice.id].sort((a, b) => a.id - b.id);
     setValue(newValue);
     setAutocompleteValue('');
     autocompleteRef.current.focus();
@@ -132,18 +182,43 @@ const CustomFieldInputMultipleChoice = forwardRef(function CustomFieldInputMulti
 
   useEffect(() => {
     setValue(props.value);
-  }, [props.value.map(choice => choice.id).join('')]);
+  }, [props.value.join('')]);
 
   useImperativeHandle(selfRef, () => ({
     get dirty() {
-      return props.value.map(v => v.id).join(',') !== this.value.join(',');
+      return props.value.join(',') !== this.value.join(',');
     },
     id: props.id,
     name: props.name,
     get value() {
-      return value ? value.map(v => v.id) : [];
+      return value;
     },
   }));
+
+  useEffect(() => {
+    const getChoices = async () => {
+      await execute(`${API_ROOT}/custom_field_choices?for_custom_fields=${props.customFieldID}`)
+        .then(({ json, mounted: isMounted }) => {
+          if (isMounted) {
+            const mungedChoices = json.results.map((result) => {
+              return {
+                ...json[result.key][result.id],
+                id: result.id,
+              };
+            });
+
+            setChoices(mungedChoices);
+          }
+        })
+        .catch((error) => {
+          if (error.error && error.error.type !== 'aborted') {
+            throw error;
+          }
+        });
+    };
+
+    getChoices();
+  }, []);
 
   return (
     <div ref={wrapperRef} className={styles['component-root']}>
@@ -166,18 +241,19 @@ const CustomFieldInputMultipleChoice = forwardRef(function CustomFieldInputMulti
             labelledBy={ids.label}
             refs={valueRefs}
           >
-            {value.map((choice, index) => (
+            {choices.length !== 0 && value.map((valueID, index) => (
               <Tag
                 defaultActive={index === 0}
-                id={`${props.id}-${choice.id}`}
-                key={`${props.id}-${choice.id}`}
+                id={`${props.id}-${valueID}`}
+                key={`${props.id}-${valueID}`}
                 onRemove={onChoiceRemove}
                 readOnly={props.readOnly}
                 ref={valueRefs[index]}
               >
-                {choice.label}
+                {choices.find(choice => choice.id === valueID).label}
               </Tag>
-            ))}
+            ))
+            }
             <input
               aria-autocomplete="list"
               aria-controls={ids.listbox}
@@ -227,38 +303,15 @@ const CustomFieldInputMultipleChoice = forwardRef(function CustomFieldInputMulti
             </div>
           </div>
         </div>
-        {expanded && (visibleChoices.length === 0 ? (<NoOptions className={styles['no-options']} id={ids.emptyMessage} />) : (
-          <Listbox
-            className={styles['popup-container']}
-            id={ids.listbox}
-            labelledBy={ids.label}
-            refs={choicesRefs}
-          >
-            {visibleChoices.map((choice, index) => (
-              <ListOption
-                key={`${props.id}-${choice.id}`}
-                onSelect={onChoiceSelect}
-                ref={choicesRefs[index]}
-                value={choice}
-              >
-                {choice.label}
-              </ListOption>
-            ))}
-          </Listbox>)
-        )}
+        {dropdownContents()}
       </FormControl>
     </div>
   );
 });
 
-const ChoiceType = PropTypes.shape({
-  id: PropTypes.number.isRequired,
-  label: PropTypes.string.isRequired,
-});
-
 CustomFieldInputMultipleChoice.propTypes = {
-  choices: PropTypes.arrayOf(ChoiceType).isRequired,
   className: PropTypes.string,
+  customFieldID: PropTypes.string.isRequired,
   errorText: PropTypes.string,
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
@@ -267,7 +320,7 @@ CustomFieldInputMultipleChoice.propTypes = {
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
-  value: PropTypes.arrayOf(ChoiceType),
+  value: PropTypes.arrayOf(PropTypes.string),
 };
 
 CustomFieldInputMultipleChoice.defaultProps = {

--- a/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.md
+++ b/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.md
@@ -17,9 +17,9 @@ The `CustomFieldInputMultipleChoice` component represents the UI for a custom fi
 | Focused element | Screen reader |
 | --------------- | ------------- |
 | Selected choice | Choice label |
-| Selected choice remove button | Remove <choice label> |
+| Selected choice remove button | Remove `<choice label>` |
 | Autocomplete textbox | Field label and any validation state |
-| Remove button | Remove all selected choices on <field label> |
+| Remove button | Remove all selected choices on `<field label>` |
 | Available choice | Choice label |
 
 ## Test Queries
@@ -36,14 +36,8 @@ The `CustomFieldInputMultipleChoice` component represents the UI for a custom fi
 ```js
 import CustomFieldInputMultipleChoice from '@mavenlink/design-system/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.jsx';
 
-const choices = [
-  { id: 1, label: 'First Choice' },
-  { id: 2, label: 'Second Choice' },
-  { id: 3, label: 'Third Choice' },
-];
-
 <CustomFieldInputMultipleChoice
-  choices={choices}
+  customFieldID="0"
   id="example-empty"
   label="This custom field is empty"
   name="example-empty"
@@ -55,38 +49,38 @@ const choices = [
 ```js
 import CustomFieldInputMultipleChoice from '@mavenlink/design-system/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.jsx';
 
-const choices = [
-  { id: 1, label: 'First Choice' },
-  { id: 2, label: 'Second Choice' },
-  { id: 3, label: 'Third Choice' },
-];
-
 <CustomFieldInputMultipleChoice
-  choices={choices}
-  id="example-readonly"
-  label="This custom field is read-only"
-  name="example-readonly"
-  readOnly
-  value={choices.slice(0, 2)}
+  customFieldID="-1"
+  id="example-no-choices"
+  label="This custom field has no choices"
+  name="example-no-choices"
+  placeholder="This input represents a custom field with no choices"
 />
 ```
 
 ```js
 import CustomFieldInputMultipleChoice from '@mavenlink/design-system/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.jsx';
 
-const choices = [
-  { id: 1, label: 'First Choice' },
-  { id: 2, label: 'Second Choice' },
-  { id: 3, label: 'Third Choice' },
-];
+<CustomFieldInputMultipleChoice
+  customFieldID="0"
+  id="example-readonly"
+  label="This custom field is read-only"
+  name="example-readonly"
+  readOnly
+  value={['0', '1']}
+/>
+```
+
+```js
+import CustomFieldInputMultipleChoice from '@mavenlink/design-system/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.jsx';
 
 <CustomFieldInputMultipleChoice
-  choices={choices}
+  customFieldID="0"
   errorText="If you're not first, you're last!"
   id="example-invalid"
   label="This custom field is invalid"
   name="example-invalid"
-  value={[choices[1]]}
+  value={['0']}
 />
 ```
 
@@ -95,114 +89,51 @@ const choices = [
 ```js
 import CustomFieldInputMultipleChoice from '@mavenlink/design-system/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.jsx';
 
-const choices = [
-  { id: 1, label: 'command (abstract role)' },
-  { id: 2, label: 'composite (abstract role)' },
-  { id: 3, label: 'input (abstract role)' },
-  { id: 4, label: 'landmark (abstract role)' },
-  { id: 5, label: 'range (abstract role)' },
-  { id: 6, label: 'roletype (abstract role)' },
-  { id: 7, label: 'section (abstract role)' },
-  { id: 8, label: 'sectionhead (abstract role)' },
-  { id: 9, label: 'select (abstract role)' },
-  { id: 10, label: 'structure (abstract role)' },
-  { id: 11, label: 'widget (abstract role)' },
-  { id: 12, label: 'window (abstract role)' },
-  { id: 13, label: 'alert (widget role)' },
-  { id: 14, label: 'alertdialog (widget role)' },
-  { id: 15, label: 'button (widget role)' },
-  { id: 16, label: 'checkbox (widget role)' },
-  { id: 17, label: 'dialog (widget role)' },
-  { id: 18, label: 'gridcell (widget role)' },
-  { id: 19, label: 'link (widget role)' },
-  { id: 20, label: 'log (widget role)' },
-  { id: 21, label: 'marquee (widget role)' },
-  { id: 22, label: 'menuitem (widget role)' },
-  { id: 23, label: 'menuitemcheckbox (widget role)' },
-  { id: 24, label: 'menuitemradio (widget role)' },
-  { id: 25, label: 'option (widget role)' },
-  { id: 26, label: 'progressbar (widget role)' },
-  { id: 27, label: 'radio (widget role)' },
-  { id: 28, label: 'scrollbar (widget role)' },
-  { id: 29, label: 'slider (widget role)' },
-  { id: 30, label: 'spinbutton (widget role)' },
-  { id: 31, label: 'status (widget role)' },
-  { id: 32, label: 'tab (widget role)' },
-  { id: 33, label: 'tabpanel (widget role)' },
-  { id: 34, label: 'textbox (widget role)' },
-  { id: 35, label: 'timer (widget role)' },
-  { id: 36, label: 'tooltip (widget role)' },
-  { id: 37, label: 'treeitem (widget role)' },
-  { id: 38, label: 'combobox (composite role)' },
-  { id: 39, label: 'grid (composite role)' },
-  { id: 40, label: 'listbox (composite role)' },
-  { id: 41, label: 'menu (composite role)' },
-  { id: 42, label: 'menubar (composite role)' },
-  { id: 43, label: 'radiogroup (composite role)' },
-  { id: 44, label: 'tablist (composite role)' },
-  { id: 45, label: 'tree (composite role)' },
-  { id: 46, label: 'treegrid (composite role)' },
-  { id: 47, label: 'article (structure role)' },
-  { id: 48, label: 'columnheader (structure role)' },
-  { id: 49, label: 'definition (structure role)' },
-  { id: 50, label: 'directory (structure role)' },
-  { id: 51, label: 'document (structure role)' },
-  { id: 52, label: 'group (structure role)' },
-  { id: 53, label: 'heading (structure role)' },
-  { id: 54, label: 'img (structure role)' },
-  { id: 55, label: 'list (structure role)' },
-  { id: 56, label: 'listitem (structure role)' },
-  { id: 57, label: 'math (structure role)' },
-  { id: 58, label: 'note (structure role)' },
-  { id: 59, label: 'presentation (structure role)' },
-  { id: 60, label: 'region (structure role)' },
-  { id: 61, label: 'row (structure role)' },
-  { id: 62, label: 'rowgroup (structure role)' },
-  { id: 63, label: 'rowheader (structure role)' },
-  { id: 64, label: 'separator (structure role)' },
-  { id: 65, label: 'toolbar (structure role)' },
-  { id: 66, label: 'application (landmark role)' },
-  { id: 67, label: 'banner (landmark role)' },
-  { id: 68, label: 'complementary (landmark role)' },
-  { id: 69, label: 'contentinfo (landmark role)' },
-  { id: 70, label: 'form (landmark role)' },
-  { id: 71, label: 'main (landmark role)' },
-  { id: 72, label: 'navigation (landmark role)' },
-  { id: 73, label: 'search (landmark role)' },
+const initialValue = [
+  '3',
+  '11',
+  '4',
+  '6',
+  '7',
+  '8',
+  '9',
 ];
-
-const value = [
-  choices[3],
-  choices[13],
-  choices[21],
-  choices[27],
-  choices[33],
-  choices[49],
+const swapValue = [
+  '5',
+  '10',
+  '11',
 ];
 
 function TestComponent() {
   const ref = React.useRef();
   const [target, setTarget] = React.useState({});
+  const [useSwapValue, setUseSwapValue] = React.useState(false);
 
   function onChange(event) {
     setTarget(event.target)
   }
 
+  function onSwapValueClick() {
+    setUseSwapValue(!useSwapValue);
+  }
+
   return (
     <React.Fragment>
       <CustomFieldInputMultipleChoice
-        choices={choices}
+        customFieldID="1"
         id="example-lotsa"
         label="This custom field has a lot of choices"
         name="example-lotsa"
         onChange={onChange}
-        value={value}
+        value={useSwapValue ? swapValue : initialValue}
       />
       <ul>
         {Object.keys(target).map(key => (
-          <li>{key}: {JSON.stringify(target[key])}</li>
+          <li key={key}>{key}: {JSON.stringify(target[key])}</li>
         ))}
+        <li>useSwapValue: {JSON.stringify(useSwapValue)}</li>
       </ul>
+      <button onClick={onSwapValueClick}>Swap Value</button>
     </React.Fragment>
   );
 }

--- a/src/components/custom-field-input-multiple-choice/test-queries.js
+++ b/src/components/custom-field-input-multiple-choice/test-queries.js
@@ -3,7 +3,9 @@ import {
   getByRole,
   queryByRole,
   screen,
+  waitForElementToBeRemoved,
 } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 export async function findAutocompleter(fieldLabel) {
   return screen.findByRole('combobox', { name: fieldLabel });
@@ -36,6 +38,10 @@ export function getSelectedChoice(fieldLabel, choiceLabel) {
   return getByRole(taglist, 'gridcell', { name: choiceLabel });
 }
 
+export function openChoices(fieldName) {
+  userEvent.click(screen.getByRole('combobox', { name: fieldName }));
+}
+
 export function queryAvailableChoice(fieldLabel, choiceLabel) {
   const listbox = screen.getByRole('listbox', { name: fieldLabel });
   return queryByRole(listbox, 'option', { name: choiceLabel });
@@ -52,4 +58,13 @@ export function queryRemoveButton(fieldLabel, choiceLabel) {
 export function querySelectedChoice(fieldLabel, choiceLabel) {
   const taglist = screen.getByRole('grid', { name: fieldLabel });
   return queryByRole(taglist, 'gridcell', { name: choiceLabel });
+}
+
+export async function waitForChoices(fieldName) {
+  openChoices(fieldName);
+  await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
+}
+
+export async function waitForChoicesNoOpen() {
+  await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
 }

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -74,14 +74,9 @@ const CustomFieldInputSingleChoice = forwardRef(function CustomFieldInputSingleC
       await execute(`${API_ROOT}/custom_field_choices?for_custom_fields=${props.customFieldID}`)
         .then(({ json, mounted }) => {
           if (mounted) {
-            const mungedChoices = json.results.map((result) => {
-              return {
-                ...json[result.key][result.id],
-                id: result.id,
-              };
-            });
+            const choiceObjects = json.results.map(result => json[result.key][result.id]);
 
-            setChoices(mungedChoices);
+            setChoices(choiceObjects);
           }
         })
         .catch((error) => {

--- a/src/components/custom-field-input-single-choice/mock-handlers.js
+++ b/src/components/custom-field-input-single-choice/mock-handlers.js
@@ -73,24 +73,16 @@ export default function handlers(delay = 0) {
       const matchingChoices = choices.filter((choice) => {
         return choice.custom_field_id === customFieldID;
       });
-      const customFieldChoices = {};
-
-      matchingChoices.forEach((choice) => {
-        customFieldChoices[choice.id] = {
-          custom_field_id: choice.custom_field_id,
-          label: choice.label,
-        };
-      });
 
       return response(
         context.status(200),
         context.json({
-          count: 2,
+          count: choices.length,
           meta: {
-            count: 2,
+            count: choices.length,
             page_count: 1,
             page_number: 0,
-            page_size: 2,
+            page_size: choices.length,
           },
           results: matchingChoices.map((choice) => {
             return {
@@ -98,7 +90,7 @@ export default function handlers(delay = 0) {
               id: choice.id,
             };
           }),
-          custom_field_choices: customFieldChoices,
+          custom_field_choices: matchingChoices,
         }),
         context.delay(delay),
       );

--- a/src/components/custom-field-input-single-choice/mock-handlers.js
+++ b/src/components/custom-field-input-single-choice/mock-handlers.js
@@ -19,6 +19,51 @@ const choices = [
     id: '2',
     label: 'Fizz',
   },
+  {
+    custom_field_id: '1',
+    id: '3',
+    label: 'Fizz (3)',
+  },
+  {
+    custom_field_id: '1',
+    id: '4',
+    label: 'Fizz (4)',
+  },
+  {
+    custom_field_id: '1',
+    id: '5',
+    label: 'Fizz (5)',
+  },
+  {
+    custom_field_id: '1',
+    id: '6',
+    label: 'Fizz (6)',
+  },
+  {
+    custom_field_id: '1',
+    id: '7',
+    label: 'Fizz (7)',
+  },
+  {
+    custom_field_id: '1',
+    id: '8',
+    label: 'Fizz (8)',
+  },
+  {
+    custom_field_id: '1',
+    id: '9',
+    label: 'Fizz (9)',
+  },
+  {
+    custom_field_id: '1',
+    id: '10',
+    label: 'Fizz (10)',
+  },
+  {
+    custom_field_id: '1',
+    id: '11',
+    label: 'This is a really long choice label (like really, really long)',
+  },
 ];
 
 export default function handlers(delay = 0) {

--- a/src/components/custom-field-input-single-choice/mock-handlers.js
+++ b/src/components/custom-field-input-single-choice/mock-handlers.js
@@ -73,6 +73,11 @@ export default function handlers(delay = 0) {
       const matchingChoices = choices.filter((choice) => {
         return choice.custom_field_id === customFieldID;
       });
+      const customFieldChoices = {};
+
+      matchingChoices.forEach((choice) => {
+        customFieldChoices[choice.id] = choice;
+      });
 
       return response(
         context.status(200),
@@ -90,7 +95,7 @@ export default function handlers(delay = 0) {
               id: choice.id,
             };
           }),
-          custom_field_choices: matchingChoices,
+          custom_field_choices: customFieldChoices,
         }),
         context.delay(delay),
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1041,9 +1041,9 @@
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@bloodyaugust/use-fetch@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@bloodyaugust/use-fetch/-/use-fetch-1.0.0.tgz#23ab920db831eb81147b40619c897668209d6e75"
-  integrity sha512-mLhr3bzMlPNjJHbF45AkIr5bJYvfklrqJ+P+sQ11fw4wsmBBDNtcTUlGPyV9VxFUx0e9RQgyxjZcBJqUHHH78g==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@bloodyaugust/use-fetch/-/use-fetch-1.1.0.tgz#871ee73d2886b6e766b4fbf10c5b1fd4c6e257ac"
+  integrity sha512-c+MY30rYOvR8sNUuD+Hw/qN/bf1vW0i0UatjHX+jrKyfjWwu05h4TQhDD0FW5sP/q5bFKcDfYAJgYDiUXVCG7Q==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"


### PR DESCRIPTION
BREAKING CHANGE(CustomFieldMultipleChoice): removed choices from the props API

Previously, choices had to be provided through the props API. Now, choices has been removed from the API, and choices are loaded based on the new customFieldID prop.

## Motivation
For ease of development, make it so that `CustomFieldMultipleChoice` doesn't require `choices` to be provided for it.

## Acceptance Criteria
- On the documentation page, each example has its own list of choices (besides the empty example)
  - MDS Site
  - Internal MDS Site
  - The multi-choice examples have a loading indicator as the choices are loaded (inline loader)

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-custom-field-multi-choice-self-fetch-176989601/
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
