### PR TITLE
fix(custom-field-input-date): does not offset value when a date with …

### DIFF
--- a/src/components/custom-field-input-date/custom-field-input-date.jsx
+++ b/src/components/custom-field-input-date/custom-field-input-date.jsx
@@ -36,8 +36,7 @@ function presentDateString(dateString) {
     return '';
   }
 
-  const timezone = new Date().toLocaleTimeString('en-us', { timeZoneName: 'short' }).split(' ')[2];
-  let date = new Date(`${dateString}  00:00:00 ${timezone}`);
+  let date = new Date(`${dateString}  00:00:00`);
 
   if (date.toString() === 'Invalid Date') {
     // Okay, we're in Safari and we need to find a way to parse the date here

--- a/src/components/custom-field-input-date/custom-field-input-date.test.jsx
+++ b/src/components/custom-field-input-date/custom-field-input-date.test.jsx
@@ -84,6 +84,11 @@ describe('src/components/custom-field-input-date/custom-field-input-date', () =>
       expect(getByLabelText('Field Date')).toHaveValue('Jul 18, 2016');
     });
 
+    it('accepts a string in format mm-dd-yyyy HH:MM:SS', () => {
+      const { getByLabelText } = render(<CustomFieldInputDate {...requiredProps} value="01-01-2020 00:00:00" />);
+      expect(getByLabelText('Field Date')).toHaveValue('Jan 1, 2020');
+    });
+
     it('updates its value', () => {
       const { rerender } = render(<CustomFieldInputDate {...requiredProps} value="07-18-2016" />);
       expect(screen.getByLabelText('Field Date')).toHaveValue('Jul 18, 2016');


### PR DESCRIPTION
## Motivation
https://www.pivotaltracker.com/story/show/177518307

## Acceptance Criteria
Entering a date like: `01-01-2020 00:00:00` should not show a value offset by one day.

## PR upkeep checklist

- [ ] Change log entry
- [ ] Label(s)
- [ ] Assignee(s)
- [ ] Deployment URL: https://mavenlink.github.io/design-system/$BRANCH/
- [ ] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
