### PR TITLE
MDS Percentage component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
-  - feat(FormControlIcons): Add FormControlIcons component
+  - feat(FormControlIcons): Add `FormControlIcons` component
+  - feat(Percentage): Add new `Percentage` component
 </details>
 
 ## v0.65.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
+  - feat(FormControlIcons): Add FormControlIcons component
 </details>
 
 ## v0.65.0

--- a/src/components/form-control-icons/__snapshots__/form-control-icons.test.jsx.snap
+++ b/src/components/form-control-icons/__snapshots__/form-control-icons.test.jsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FormControlIcons> has defaults 1`] = `
+<body>
+  <div>
+    <div
+      class="icons"
+    />
+  </div>
+</body>
+`;

--- a/src/components/form-control-icons/form-control-icons.css
+++ b/src/components/form-control-icons/form-control-icons.css
@@ -1,0 +1,13 @@
+@import '../../styles/spacing.css';
+@import '../../styles/colors-v2.css';
+
+.icons {
+  align-items: center;
+  display: grid;
+  grid-auto-flow: column;
+  grid-gap: var(--spacing-small);
+  position: absolute;
+  right: var(--spacing-medium);
+  transform: translateY(-50%);
+  top: 50%;
+}

--- a/src/components/form-control-icons/form-control-icons.css
+++ b/src/components/form-control-icons/form-control-icons.css
@@ -1,5 +1,4 @@
 @import '../../styles/spacing.css';
-@import '../../styles/colors-v2.css';
 
 .icons {
   align-items: center;

--- a/src/components/form-control-icons/form-control-icons.jsx
+++ b/src/components/form-control-icons/form-control-icons.jsx
@@ -13,7 +13,6 @@ export default function FormControlIcons({
     <div className={className}>
       {!!validationMessage && (
         <Icon
-          className={styles['invalid-icon']}
           icon={cautionSvg}
           label={validationMessage}
         />

--- a/src/components/form-control-icons/form-control-icons.jsx
+++ b/src/components/form-control-icons/form-control-icons.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Icon from '../icon/icon.jsx';
+import cautionSvg from '../../svgs/caution.svg';
+import styles from './form-control-icons.css';
+
+export default function FormControlIcons({
+  children,
+  className,
+  validationMessage,
+}) {
+  return (
+    <div className={className}>
+      {!!validationMessage && (
+        <Icon
+          className={styles['invalid-icon']}
+          icon={cautionSvg}
+          label={validationMessage}
+        />
+      )}
+      {children}
+    </div>
+  );
+}
+
+FormControlIcons.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  validationMessage: PropTypes.string,
+};
+
+FormControlIcons.defaultProps = {
+  children: undefined,
+  className: styles.icons,
+  validationMessage: '',
+};

--- a/src/components/form-control-icons/form-control-icons.md
+++ b/src/components/form-control-icons/form-control-icons.md
@@ -1,0 +1,37 @@
+`FormControlIcons` provides a composable way to provide a validation icon and, optionally, other icons in the same container.
+
+### Examples
+
+Full usage with FormControl and `<input>`
+```js
+import FormControl from '@mavenlink/design-system/src/components/form-control/form-control.jsx';
+import Icon from '@mavenlink/design-system/src/components/icon/icon.jsx';
+import calendarSVG from '@mavenlink/design-system/src/svgs/calendar.svg';
+
+function TestComponent() {
+  const [valid, setValid] = React.useState(false);
+  const errorMessage = 'This is an error';
+
+  function handleClick() {
+    setValid(!valid);
+  }
+
+  return (
+    <div style={{
+      width: '150px'
+    }}>
+      <FormControl id="ex-1-control" label="Example Input" error={valid ? '' : errorMessage}>
+        <input style={{
+          height: '20px'
+        }} id="ex-1" />
+        <FormControlIcons validationMessage={valid ? '' : errorMessage}>
+          <Icon icon={calendarSVG} label="open calendar" />
+        </FormControlIcons>
+      </FormControl>
+      <button onClick={handleClick} >Toggle Validity</button>
+    </div>
+  )
+}
+
+<TestComponent />
+```

--- a/src/components/form-control-icons/form-control-icons.test.jsx
+++ b/src/components/form-control-icons/form-control-icons.test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {
+  render,
+  screen,
+} from '@testing-library/react';
+import calendarSvg from '../../svgs/calendar.svg';
+import Icon from '../icon/icon.jsx';
+import FormControlIcons from './form-control-icons.jsx';
+
+describe('<FormControlIcons>', () => {
+  it('has defaults', () => {
+    render(<FormControlIcons />);
+    expect(document.body).toMatchSnapshot();
+  });
+
+  it('renders children', () => {
+    render(<FormControlIcons><Icon icon={calendarSvg} label="kerfuffle" /></FormControlIcons>);
+    expect(screen.getByTitle('kerfuffle')).toBeInTheDocument();
+  });
+
+  it('sets className', () => {
+    const { container } = render(<FormControlIcons className="test-class" />);
+    expect(container.querySelector('.test-class')).toBeInTheDocument();
+  });
+
+  it('shows caution icon if we have a validationMessage', () => {
+    render(<FormControlIcons validationMessage="This is an error" />);
+    expect(screen.getByTitle('This is an error')).toBeInTheDocument();
+  });
+});

--- a/src/components/percentage/__snapshots__/percentage.test.jsx.snap
+++ b/src/components/percentage/__snapshots__/percentage.test.jsx.snap
@@ -46,6 +46,6 @@ Object {
   "dirty": false,
   "id": "foo",
   "name": undefined,
-  "value": NaN,
+  "value": undefined,
 }
 `;

--- a/src/components/percentage/__snapshots__/percentage.test.jsx.snap
+++ b/src/components/percentage/__snapshots__/percentage.test.jsx.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Percentage has defaults 1`] = `
+<body>
+  <div>
+    <div
+      class="container"
+      role="presentation"
+    >
+      <label
+        class="label"
+        for="foo"
+      >
+        the label
+      </label>
+      <div
+        class="control-container"
+      >
+        <input
+          aria-describedby="fooHint"
+          class="input"
+          id="foo"
+          max="100"
+          min="0"
+          step="0.01"
+          type="number"
+          value=""
+        />
+        <div
+          class="icons-container"
+        >
+          <span
+            class="percent-sign"
+          >
+            %
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Percentage has defaults 2`] = `
+Object {
+  "dirty": false,
+  "id": "foo",
+  "name": undefined,
+  "value": NaN,
+}
+`;

--- a/src/components/percentage/percentage.css
+++ b/src/components/percentage/percentage.css
@@ -8,14 +8,8 @@
 }
 
 .input {
-  border: 1px solid var(--mds-grey-12);
-  border-radius: 3px;
-  box-sizing: border-box;
-  font: var(--mds-type-content);
-  height: var(--spacing-x-large);
-  margin: 0;
+  composes: input from "../input/input.css";
   padding: 0 calc(var(--spacing-x-large) + var(--spacing-large)) 0 var(--spacing-medium);
-  width: 100%;
 }
 
 .input::placeholder {
@@ -26,22 +20,9 @@
   background-color: var(--mds-grey-3);
 }
 
-.invalid-icon {
-  box-sizing: border-box;
-  pointer-events: none;
-  position: absolute;
-  right: 6px;
-  top: 50%;
-  transform: translateY(-50%);
-}
-
 .invalid-input {
+  composes: invalid-input from "../input/input.css";
   composes: input;
-  border-color: var(--mds-red-100);
-}
-
-.invalid-input:hover {
-  border-color: var(--mds-red-100);
 }
 
 .percent-sign {

--- a/src/components/percentage/percentage.css
+++ b/src/components/percentage/percentage.css
@@ -1,0 +1,51 @@
+@import '../../styles/colors-v2.css';
+@import "../../styles/spacing.css";
+@import "../../styles/typography-v2.css";
+
+.icons-container {
+  composes: icons from "../form-control-icons/form-control-icons.css";
+  pointer-events: none;
+}
+
+.input {
+  border: 1px solid var(--mds-grey-12);
+  border-radius: 3px;
+  box-sizing: border-box;
+  font: var(--mds-type-content);
+  height: var(--spacing-x-large);
+  margin: 0;
+  padding: 0 calc(var(--spacing-x-large) + var(--spacing-large)) 0 var(--spacing-medium);
+  width: 100%;
+}
+
+.input::placeholder {
+  color: var(--mds-grey-54);
+}
+
+.input:read-only {
+  background-color: var(--mds-grey-3);
+}
+
+.invalid-icon {
+  box-sizing: border-box;
+  pointer-events: none;
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.invalid-input {
+  composes: input;
+  border-color: var(--mds-red-100);
+}
+
+.invalid-input:hover {
+  border-color: var(--mds-red-100);
+}
+
+.percent-sign {
+  color: var(--mds-grey-38);
+  font: var(--mds-type-content);
+  user-select: none;
+}

--- a/src/components/percentage/percentage.jsx
+++ b/src/components/percentage/percentage.jsx
@@ -1,0 +1,148 @@
+import PropTypes from 'prop-types';
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from 'react';
+import FormControl from '../form-control/form-control.jsx';
+import FormControlIcons from '../form-control-icons/form-control-icons.jsx';
+import styles from './percentage.css';
+import useMounted from '../../hooks/use-mounted.js';
+import useValidation from '../../hooks/use-validation.jsx';
+
+function getClassName(className, validationMessage) {
+  if (className) return className;
+  return validationMessage ? styles['invalid-input'] : styles.input;
+}
+
+const Percentage = forwardRef(function Percentage(props, forwardedRef) {
+  const fallbackRef = useRef();
+  const ref = forwardedRef || fallbackRef;
+  const inputRef = useRef();
+  const mounted = useMounted();
+  const [validationMessage, validate] = useValidation(props.validationMessage, inputRef);
+
+  function onBlur(event) {
+    validate();
+    props.onBlur(event);
+  }
+
+  function onChange(event) {
+    validate();
+    props.onChange(event);
+  }
+
+  useEffect(() => {
+    if (!mounted.current) return;
+
+    // The MDS Input is using an uncontrolled `<input>`.
+    // In order to set a new provided value prop, we
+    // set the internal state of the `<input>`.
+    inputRef.current.value = props.value || '';
+  }, [props.value]);
+
+  useImperativeHandle(ref, () => ({
+    get dirty() {
+      const providedValue = props.value || NaN;
+      return !Object.is(providedValue, this.value);
+    },
+    id: props.id,
+    name: props.name,
+    get value() {
+      return parseFloat(inputRef.current.value);
+    },
+  }));
+
+  return (
+    <FormControl
+      className={props.cssContainer}
+      error={validationMessage}
+      id={props.id}
+      label={props.label}
+      readOnly={props.readOnly}
+      required={props.required}
+    >
+      <input
+        aria-describedby={`${props.id}Hint`}
+        autoFocus={props.autoFocus} // eslint-disable-line jsx-a11y/no-autofocus
+        className={getClassName(props.className, validationMessage)}
+        defaultValue={props.value}
+        id={props.id}
+        max={100}
+        min={0}
+        step={0.01}
+        name={props.name}
+        onBlur={onBlur}
+        onChange={onChange}
+        onFocus={props.onFocus}
+        onInput={props.onInput}
+        onKeyDown={props.onKeyDown}
+        placeholder={props.placeholder}
+        readOnly={props.readOnly}
+        ref={inputRef}
+        required={props.required}
+        type="number"
+      />
+      <FormControlIcons validationMessage={validationMessage} className={styles['icons-container']}>
+        <span className={styles['percent-sign']}>%</span>
+      </FormControlIcons>
+    </FormControl>
+  );
+});
+
+Percentage.propTypes = {
+  autoFocus: PropTypes.bool,
+  className: PropTypes.string,
+  cssContainer: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  onInput: PropTypes.func,
+  onKeyDown: PropTypes.func,
+  placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
+  required: PropTypes.bool,
+  validationMessage: PropTypes.string,
+  value: (props, propName, componentName) => {
+    const propValue = props[propName];
+
+    if (propValue === undefined) {
+      return undefined;
+    }
+
+    if (typeof propValue !== 'number') {
+      return new Error(`Invalid prop "value" supplied to ${componentName}: must be a number.`);
+    }
+
+    if (propValue > 100 || propValue < 0) {
+      return new Error(`Invalid prop "value" supplied to ${componentName}: ` +
+      `must be less than 100 and greater than 0 (was ${propValue}).`);
+    }
+
+    return undefined;
+  },
+};
+
+Percentage.defaultProps = {
+  autoFocus: undefined,
+  className: undefined,
+  cssContainer: styles.container,
+  cssLabel: undefined,
+  name: undefined,
+  onBlur: () => {},
+  onChange: () => {},
+  onFocus: undefined,
+  onInput: undefined,
+  onKeyDown: undefined,
+  placeholder: undefined,
+  readOnly: undefined,
+  required: undefined,
+  validationMessage: '',
+  value: undefined,
+};
+
+export default Percentage;

--- a/src/components/percentage/percentage.jsx
+++ b/src/components/percentage/percentage.jsx
@@ -44,13 +44,13 @@ const Percentage = forwardRef(function Percentage(props, forwardedRef) {
 
   useImperativeHandle(ref, () => ({
     get dirty() {
-      const providedValue = props.value || NaN;
+      const providedValue = props.value || undefined;
       return !Object.is(providedValue, this.value);
     },
     id: props.id,
     name: props.name,
     get value() {
-      return parseFloat(inputRef.current.value);
+      return parseFloat(inputRef.current.value) || undefined;
     },
   }));
 

--- a/src/components/percentage/percentage.jsx
+++ b/src/components/percentage/percentage.jsx
@@ -1,14 +1,13 @@
 import PropTypes from 'prop-types';
 import React, {
   forwardRef,
-  useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useRef,
 } from 'react';
 import FormControl from '../form-control/form-control.jsx';
 import FormControlIcons from '../form-control-icons/form-control-icons.jsx';
 import styles from './percentage.css';
-import useMounted from '../../hooks/use-mounted.js';
 import useValidation from '../../hooks/use-validation.jsx';
 
 function getClassName(className, validationMessage) {
@@ -20,25 +19,24 @@ const Percentage = forwardRef(function Percentage(props, forwardedRef) {
   const fallbackRef = useRef();
   const ref = forwardedRef || fallbackRef;
   const inputRef = useRef();
-  const mounted = useMounted();
   const [validationMessage, validate] = useValidation(props.validationMessage, inputRef);
+  const classNames = {
+    container: props.cssContainer,
+    input: props.className,
+  };
+  const ids = {
+    validationMessage: `${props.id}Hint`,
+  };
 
-  function onBlur(event) {
+  function onBlur() {
     validate();
-    props.onBlur(event);
   }
 
   function onChange(event) {
-    validate();
     props.onChange(event);
   }
 
-  useEffect(() => {
-    if (!mounted.current) return;
-
-    // The MDS Input is using an uncontrolled `<input>`.
-    // In order to set a new provided value prop, we
-    // set the internal state of the `<input>`.
+  useLayoutEffect(() => {
     inputRef.current.value = props.value || '';
   }, [props.value]);
 
@@ -50,13 +48,13 @@ const Percentage = forwardRef(function Percentage(props, forwardedRef) {
     id: props.id,
     name: props.name,
     get value() {
-      return parseFloat(inputRef.current.value) || undefined;
+      return window.parseFloat(inputRef.current.value) || undefined;
     },
   }));
 
   return (
     <FormControl
-      className={props.cssContainer}
+      className={classNames.container}
       error={validationMessage}
       id={props.id}
       label={props.label}
@@ -64,9 +62,8 @@ const Percentage = forwardRef(function Percentage(props, forwardedRef) {
       required={props.required}
     >
       <input
-        aria-describedby={`${props.id}Hint`}
-        autoFocus={props.autoFocus} // eslint-disable-line jsx-a11y/no-autofocus
-        className={getClassName(props.className, validationMessage)}
+        aria-describedby={ids.validationMessage}
+        className={getClassName(classNames.input, validationMessage)}
         defaultValue={props.value}
         id={props.id}
         max={100}
@@ -75,9 +72,6 @@ const Percentage = forwardRef(function Percentage(props, forwardedRef) {
         name={props.name}
         onBlur={onBlur}
         onChange={onChange}
-        onFocus={props.onFocus}
-        onInput={props.onInput}
-        onKeyDown={props.onKeyDown}
         placeholder={props.placeholder}
         readOnly={props.readOnly}
         ref={inputRef}
@@ -92,17 +86,12 @@ const Percentage = forwardRef(function Percentage(props, forwardedRef) {
 });
 
 Percentage.propTypes = {
-  autoFocus: PropTypes.bool,
   className: PropTypes.string,
   cssContainer: PropTypes.string,
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   name: PropTypes.string,
-  onBlur: PropTypes.func,
   onChange: PropTypes.func,
-  onFocus: PropTypes.func,
-  onInput: PropTypes.func,
-  onKeyDown: PropTypes.func,
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
@@ -128,16 +117,11 @@ Percentage.propTypes = {
 };
 
 Percentage.defaultProps = {
-  autoFocus: undefined,
   className: undefined,
   cssContainer: styles.container,
-  cssLabel: undefined,
   name: undefined,
-  onBlur: () => {},
   onChange: () => {},
   onFocus: undefined,
-  onInput: undefined,
-  onKeyDown: undefined,
   placeholder: undefined,
   readOnly: undefined,
   required: undefined,

--- a/src/components/percentage/percentage.md
+++ b/src/components/percentage/percentage.md
@@ -1,0 +1,17 @@
+The `Percentage` component allows for representing a percentage in the range of [0, 100] with up to 2 significant digits.
+
+```js
+<Percentage id="ex-1" label="Default example" />
+```
+
+```js
+<Percentage id="ex-2" label="Required example" required />
+```
+
+```js
+<Percentage id="ex-3" label="Server error example" validationMessage="The server returned an error." />
+```
+
+```js
+<Percentage id="ex-4" label="Read-only / disabled example" readOnly />
+```

--- a/src/components/percentage/percentage.md
+++ b/src/components/percentage/percentage.md
@@ -15,3 +15,24 @@ The `Percentage` component allows for representing a percentage in the range of 
 ```js
 <Percentage id="ex-4" label="Read-only / disabled example" readOnly />
 ```
+
+## Ref API Example
+
+```jsx
+import Percentage from '@mavenlink/design-system/src/components/percentage/percentage.jsx';
+import RefExample from '@mavenlink/design-system/src/components/ref-example/ref-example.jsx';
+
+const ref = React.createRef();
+
+<RefExample ref={ref}>
+  {({ onChange }) => (
+    <Percentage 
+      id="ex-5" 
+      label="Ref example Percentage"
+      name="percentage-ref"
+      onChange={onChange}
+      ref={ref}
+    />
+  )}
+</RefExample>
+```

--- a/src/components/percentage/percentage.test.jsx
+++ b/src/components/percentage/percentage.test.jsx
@@ -2,7 +2,6 @@ import React, {
   createRef,
 } from 'react';
 import {
-  fireEvent,
   render,
   screen,
 } from '@testing-library/react';
@@ -20,13 +19,6 @@ describe('Percentage', () => {
     render(<Percentage {...requiredProps} ref={ref} />);
     expect(document.body).toMatchSnapshot();
     expect(ref.current).toMatchSnapshot();
-  });
-
-  describe('autoFocus API', () => {
-    it('sets the autoFocus attribute', () => {
-      render(<Percentage {...requiredProps} autoFocus />);
-      expect(screen.getByLabelText('the label')).toHaveFocus();
-    });
   });
 
   describe('className API', () => {
@@ -107,48 +99,12 @@ describe('Percentage', () => {
     });
   });
 
-  describe('onBlur API', () => {
-    it('sets the onblur handler', () => {
-      const onBlurSpy = jest.fn();
-      render(<Percentage {...requiredProps} onBlur={onBlurSpy} />);
-      fireEvent.blur(screen.getByLabelText('the label'));
-      expect(onBlurSpy.mock.calls.length).toEqual(1);
-    });
-  });
-
   describe('onChange API', () => {
     it('sets the onchange handler', () => {
       const onChangeSpy = jest.fn();
       render(<Percentage {...requiredProps} onChange={onChangeSpy} />);
-      fireEvent.change(screen.getByLabelText('the label'), { target: { value: '100' } });
-      expect(onChangeSpy.mock.calls.length).toEqual(1);
-    });
-  });
-
-  describe('onFocus API', () => {
-    it('sets the onFocus handler', () => {
-      const onFocusSpy = jest.fn();
-      render(<Percentage {...requiredProps} onFocus={onFocusSpy} />);
-      fireEvent.focus(screen.getByLabelText('the label'));
-      expect(onFocusSpy.mock.calls.length).toEqual(1);
-    });
-  });
-
-  describe('onInput API', () => {
-    it('sets the onInput handler', () => {
-      const onInputSpy = jest.fn();
-      render(<Percentage {...requiredProps} onInput={onInputSpy} />);
-      fireEvent.input(screen.getByLabelText('the label'));
-      expect(onInputSpy.mock.calls.length).toEqual(1);
-    });
-  });
-
-  describe('onKeyDown API', () => {
-    it('sets the onKeyDown handler', () => {
-      const onKeyDownSpy = jest.fn();
-      render(<Percentage {...requiredProps} onKeyDown={onKeyDownSpy} />);
-      fireEvent.keyDown(screen.getByLabelText('the label'));
-      expect(onKeyDownSpy.mock.calls.length).toEqual(1);
+      userEvent.type(screen.getByLabelText('the label'), '100');
+      expect(onChangeSpy.mock.calls.length).toEqual(3);
     });
   });
 
@@ -161,8 +117,11 @@ describe('Percentage', () => {
 
   describe('readOnly API', () => {
     it('sets the readOnly attribute', () => {
-      render(<Percentage {...requiredProps} readOnly />);
+      const { rerender } = render(<Percentage {...requiredProps} readOnly />);
       expect(screen.getByLabelText('the label')).toHaveAttribute('readonly');
+
+      rerender(<Percentage {...requiredProps} readOnly={false} />);
+      expect(screen.getByLabelText('the label')).not.toHaveAttribute('readonly');
     });
   });
 
@@ -191,18 +150,6 @@ describe('Percentage', () => {
       render(<Percentage {...requiredProps} required={true} />);
       expect(screen.getByLabelText('the label')).toBeInvalid();
       expect(screen.getByLabelText('the label')).toHaveDescription('');
-    });
-
-    it('is invalid after typing', async () => {
-      render(<Percentage {...requiredProps} required={true} />);
-      userEvent.type(screen.getByLabelText('the label'), '1');
-      expect(screen.getByLabelText('the label')).toHaveValue(1);
-      expect(screen.getByLabelText('the label')).toBeValid();
-      expect(screen.getByLabelText('the label')).toHaveDescription('');
-      userEvent.type(screen.getByLabelText('the label'), '{backspace}');
-      expect(screen.getByLabelText('the label')).toHaveValue(null);
-      expect(screen.getByLabelText('the label')).toBeInvalid();
-      expect(screen.getByLabelText('the label')).toHaveDescription('Constraints not satisfied');
     });
 
     it('is invalid after tabbing through', async () => {

--- a/src/components/percentage/percentage.test.jsx
+++ b/src/components/percentage/percentage.test.jsx
@@ -253,7 +253,7 @@ describe('Percentage', () => {
       expect(ref.current.value).toBe(12);
 
       rerender(<Percentage {...requiredProps} ref={ref} value={undefined} />);
-      expect(ref.current.value).toBeNaN();
+      expect(ref.current.value).toBeUndefined();
       userEvent.type(screen.getByLabelText('the label'), '1');
       expect(ref.current.value).toBe(1);
     });

--- a/src/components/percentage/percentage.test.jsx
+++ b/src/components/percentage/percentage.test.jsx
@@ -1,0 +1,261 @@
+import React, {
+  createRef,
+} from 'react';
+import {
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Percentage from './percentage.jsx';
+
+describe('Percentage', () => {
+  const requiredProps = {
+    id: 'foo',
+    label: 'the label',
+  };
+
+  it('has defaults', () => {
+    const ref = createRef();
+    render(<Percentage {...requiredProps} ref={ref} />);
+    expect(document.body).toMatchSnapshot();
+    expect(ref.current).toMatchSnapshot();
+  });
+
+  describe('autoFocus API', () => {
+    it('sets the autoFocus attribute', () => {
+      render(<Percentage {...requiredProps} autoFocus />);
+      expect(screen.getByLabelText('the label')).toHaveFocus();
+    });
+  });
+
+  describe('className API', () => {
+    it('sets <input> className', () => {
+      render(<Percentage {...requiredProps} className="test-class" />);
+      expect(screen.getByLabelText('the label')).toHaveClass('test-class');
+    });
+  });
+
+  describe('cssContainer API', () => {
+    it('sets container className', () => {
+      render(<Percentage {...requiredProps} cssContainer="test-class" />);
+      expect(screen.getByLabelText('the label').parentElement.parentElement).toHaveClass('test-class');
+    });
+  });
+
+  describe('dirty API', () => {
+    it('is unset without any changes', () => {
+      const ref = createRef();
+      render(<Percentage {...requiredProps} ref={ref} />);
+      expect(ref.current.dirty).toBe(false);
+    });
+
+    it('is set with any changes', () => {
+      const ref = createRef();
+      render(<Percentage {...requiredProps} ref={ref} />);
+      userEvent.type(screen.getByLabelText('the label'), '1');
+      expect(ref.current.dirty).toBe(true);
+    });
+
+    it('is unset with changes back to initial state', () => {
+      const ref = createRef();
+      render(<Percentage {...requiredProps} ref={ref} />);
+      userEvent.type(screen.getByLabelText('the label'), '1');
+      userEvent.type(screen.getByLabelText('the label'), '{backspace}');
+      expect(ref.current.dirty).toBe(false);
+    });
+
+    it('is unset with changes and new value prop', () => {
+      const ref = createRef();
+      const { rerender } = render(<Percentage {...requiredProps} ref={ref} />);
+      userEvent.type(screen.getByLabelText('the label'), '1');
+      rerender(<Percentage {...requiredProps} ref={ref} value={1} />);
+      expect(ref.current.dirty).toBe(false);
+    });
+  });
+
+  describe('id API', () => {
+    it('sets the ID', () => {
+      render(<Percentage {...requiredProps} id="test-id" />);
+      expect(screen.getByLabelText('the label')).toHaveAttribute('id', 'test-id');
+    });
+
+    it('is set on the ref', () => {
+      const ref = createRef();
+      render(<Percentage {...requiredProps} id="unique-id" ref={ref} />);
+      expect(ref.current.id).toBe('unique-id');
+    });
+  });
+
+  describe('label API', () => {
+    it('can be set', () => {
+      render(<Percentage {...requiredProps} label="Unique label" />);
+      expect(screen.getByLabelText('Unique label')).toBeInTheDocument();
+    });
+  });
+
+  describe('name API', () => {
+    it('sets the name attribute', () => {
+      render(<Percentage {...requiredProps} name="test-name" />);
+      expect(screen.getByLabelText('the label')).toHaveAttribute('name', 'test-name');
+    });
+
+    it('is set on the ref', () => {
+      const ref = createRef();
+      render(<Percentage {...requiredProps} name="unique-name" ref={ref} />);
+      expect(ref.current.name).toBe('unique-name');
+    });
+  });
+
+  describe('onBlur API', () => {
+    it('sets the onblur handler', () => {
+      const onBlurSpy = jest.fn();
+      render(<Percentage {...requiredProps} onBlur={onBlurSpy} />);
+      fireEvent.blur(screen.getByLabelText('the label'));
+      expect(onBlurSpy.mock.calls.length).toEqual(1);
+    });
+  });
+
+  describe('onChange API', () => {
+    it('sets the onchange handler', () => {
+      const onChangeSpy = jest.fn();
+      render(<Percentage {...requiredProps} onChange={onChangeSpy} />);
+      fireEvent.change(screen.getByLabelText('the label'), { target: { value: '100' } });
+      expect(onChangeSpy.mock.calls.length).toEqual(1);
+    });
+  });
+
+  describe('onFocus API', () => {
+    it('sets the onFocus handler', () => {
+      const onFocusSpy = jest.fn();
+      render(<Percentage {...requiredProps} onFocus={onFocusSpy} />);
+      fireEvent.focus(screen.getByLabelText('the label'));
+      expect(onFocusSpy.mock.calls.length).toEqual(1);
+    });
+  });
+
+  describe('onInput API', () => {
+    it('sets the onInput handler', () => {
+      const onInputSpy = jest.fn();
+      render(<Percentage {...requiredProps} onInput={onInputSpy} />);
+      fireEvent.input(screen.getByLabelText('the label'));
+      expect(onInputSpy.mock.calls.length).toEqual(1);
+    });
+  });
+
+  describe('onKeyDown API', () => {
+    it('sets the onKeyDown handler', () => {
+      const onKeyDownSpy = jest.fn();
+      render(<Percentage {...requiredProps} onKeyDown={onKeyDownSpy} />);
+      fireEvent.keyDown(screen.getByLabelText('the label'));
+      expect(onKeyDownSpy.mock.calls.length).toEqual(1);
+    });
+  });
+
+  describe('placeholder API', () => {
+    it('sets the placeholder attribute', () => {
+      render(<Percentage {...requiredProps} placeholder="test-placeholder" />);
+      expect(screen.getByLabelText('the label')).toHaveAttribute('placeholder', 'test-placeholder');
+    });
+  });
+
+  describe('readOnly API', () => {
+    it('sets the readOnly attribute', () => {
+      render(<Percentage {...requiredProps} readOnly />);
+      expect(screen.getByLabelText('the label')).toHaveAttribute('readonly');
+    });
+  });
+
+  describe('ref API', () => {
+    it('can be set', () => {
+      const ref = React.createRef();
+      render(<Percentage {...requiredProps} ref={ref} value={100} />);
+      expect(ref.current.value).toEqual(100);
+    });
+  });
+
+  describe('required API', () => {
+    it('can be set', () => {
+      render(<Percentage {...requiredProps} required={true} />);
+      expect(screen.getByLabelText('the label')).toBeRequired();
+      expect(screen.getByLabelText('the label')).toBeInvalid();
+    });
+
+    it('can be unset', () => {
+      render(<Percentage {...requiredProps} required={false} />);
+      expect(screen.getByLabelText('the label')).not.toBeRequired();
+      expect(screen.getByLabelText('the label')).toBeValid();
+    });
+
+    it('is invalid on mount but does not have an error message', () => {
+      render(<Percentage {...requiredProps} required={true} />);
+      expect(screen.getByLabelText('the label')).toBeInvalid();
+      expect(screen.getByLabelText('the label')).toHaveDescription('');
+    });
+
+    it('is invalid after typing', async () => {
+      render(<Percentage {...requiredProps} required={true} />);
+      userEvent.type(screen.getByLabelText('the label'), '1');
+      expect(screen.getByLabelText('the label')).toHaveValue(1);
+      expect(screen.getByLabelText('the label')).toBeValid();
+      expect(screen.getByLabelText('the label')).toHaveDescription('');
+      userEvent.type(screen.getByLabelText('the label'), '{backspace}');
+      expect(screen.getByLabelText('the label')).toHaveValue(null);
+      expect(screen.getByLabelText('the label')).toBeInvalid();
+      expect(screen.getByLabelText('the label')).toHaveDescription('Constraints not satisfied');
+    });
+
+    it('is invalid after tabbing through', async () => {
+      render(<Percentage {...requiredProps} required={true} />);
+      userEvent.tab();
+      expect(document.activeElement).toBe(screen.getByLabelText('the label'));
+      expect(screen.getByLabelText('the label')).toBeInvalid();
+      expect(screen.getByLabelText('the label')).toHaveDescription('');
+      userEvent.tab();
+      expect(document.activeElement).not.toBe(screen.getByLabelText('the label'));
+      expect(screen.getByLabelText('the label')).toBeInvalid();
+      expect(screen.getByLabelText('the label')).toHaveDescription('Constraints not satisfied');
+    });
+  });
+
+  describe('validationMessage API', () => {
+    it('can be set', () => {
+      render(<Percentage {...requiredProps} validationMessage="unique error" />);
+      expect(screen.getByLabelText('the label')).toBeInvalid();
+      expect(screen.getByLabelText('the label')).toHaveDescription('unique error');
+      expect(screen.getByRole('img', { name: 'unique error' })).toBeInTheDocument();
+    });
+
+    it('can be unset', () => {
+      render(<Percentage {...requiredProps} validationMessage="" />);
+      expect(screen.getByLabelText('the label')).toBeValid();
+      expect(screen.getByLabelText('the label')).toHaveDescription('');
+    });
+  });
+
+  describe('value API', () => {
+    it('sets the value', () => {
+      render(<Percentage {...requiredProps} value={100} />);
+      expect(screen.getByLabelText('the label')).toHaveValue(100);
+    });
+
+    it('updates the value', () => {
+      const { rerender } = render(<Percentage {...requiredProps} value={1} />);
+      rerender(<Percentage {...requiredProps} value={100} />);
+      expect(screen.getByLabelText('the label')).toHaveValue(100);
+    });
+
+    it('set on the ref', () => {
+      const ref = createRef();
+      const { rerender } = render(<Percentage {...requiredProps} ref={ref} value={1} />);
+      expect(ref.current.value).toBe(1);
+      userEvent.type(screen.getByLabelText('the label'), '2');
+      expect(ref.current.value).toBe(12);
+
+      rerender(<Percentage {...requiredProps} ref={ref} value={undefined} />);
+      expect(ref.current.value).toBeNaN();
+      userEvent.type(screen.getByLabelText('the label'), '1');
+      expect(ref.current.value).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
Co-authored-by: Chris Bacon <cbacon@mavenlink.com>
## Motivation
We need an easy way for a user to set a percentage datum. 

## Acceptance Criteria
- The Percentage component looks and acts like an Number
  - If possible, hide the up/down arrows. 
- The `%` is on the right side with appropriate spacing
  - Note: it is to the left of the invalid icon
  - It is not focusable / interactive
  - It does not have a label
  - It is not clickable -- instead it focuses the <input>
- Validations
  - It validates on blur (any messages appear/disappear)
  - 0.00 <= n <= 100.00
  - Only 2 decimal points (no rounding!)

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-mds-percentage-177481296/
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check
- [x] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
