### PR TITLE
fix(test-queries): ensure `waitForElementToBeRemoved` is given a valid element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
+  - refactor(test-queries): ensure `waitForElementToBeRemoved` is given a valid element
 </details>
 
 ## v0.71.0

--- a/src/components/custom-field-input-multiple-choice/test-queries.js
+++ b/src/components/custom-field-input-multiple-choice/test-queries.js
@@ -60,11 +60,12 @@ export function querySelectedChoice(fieldLabel, choiceLabel) {
   return queryByRole(taglist, 'gridcell', { name: choiceLabel });
 }
 
-export async function waitForChoices(fieldName) {
-  openChoices(fieldName);
-  if (screen.queryAllByRole('progressbar')) {
-    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
-  }
+export async function waitForChoices(fieldLabel) {
+  openChoices(fieldLabel);
+
+  const listbox = screen.getByRole('listbox', { name: fieldLabel });
+  const progressbar = queryByRole(listbox, 'progressbar');
+  if (progressbar) await waitForElementToBeRemoved(progressbar);
 }
 
 export async function waitForChoicesNoOpen() {

--- a/src/components/custom-field-input-single-choice/test-queries.js
+++ b/src/components/custom-field-input-single-choice/test-queries.js
@@ -1,5 +1,6 @@
 import {
   screen,
+  queryByRole,
   waitForElementToBeRemoved,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -24,7 +25,8 @@ export function selectChoice(fieldLabel, choiceText) {
 
 export async function waitForChoices(fieldName) {
   openChoices(fieldName);
-  if (screen.queryAllByRole('progressbar')) {
-    await waitForElementToBeRemoved(() => screen.queryAllByRole('progressbar'));
-  }
+
+  const listbox = screen.getByRole('listbox', { name: fieldName });
+  const progressbar = queryByRole(listbox, 'progressbar');
+  if (progressbar) await waitForElementToBeRemoved(progressbar);
 }


### PR DESCRIPTION
## Motivation

`waitForChoices` is intermittently failing. Looks like `waitForElementToBeRemoved` fails when it does not get a valid element. 

We don't need to pass a callback and it's easier if we actually find the element we want to be removed. 

## Acceptance Criteria

- Green CI

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [ ] Deployment URL: https://mavenlink.github.io/design-system/$BRANCH/
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check https://github.com/mavenlink/mavenlink/pull/24734
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
