### PR TITLE
Webinf mds multi autocompleter 177213842

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
+  - feat(MultiSelect): Add `MultiSelect` component
 </details>
 
 ## v0.70.0

--- a/src/components/multi-autocompleter/__snapshots__/multi-select.test.jsx.snap
+++ b/src/components/multi-autocompleter/__snapshots__/multi-select.test.jsx.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<MultiAutocompleter> has defaults 1`] = `
+<body>
+  <div>
+    <div
+      id="test-id"
+    >
+      <div
+        role="presentation"
+      >
+        <label
+          class="label"
+          for="test-id-autocomplete"
+          id="test-id-label"
+        >
+          test label
+        </label>
+        <div
+          class="control-container"
+        >
+          <div
+            class="form-control-children-container"
+            role="presentation"
+          >
+            <div
+              aria-labelledby="test-id-label"
+              class="tag-list"
+              role="grid"
+            >
+              <input
+                aria-autocomplete="list"
+                aria-controls="test-id-listbox"
+                aria-describedby="test-id-empty"
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-labelledby="test-id-label"
+                autocomplete="off"
+                class="input"
+                id="test-id-autocomplete"
+                role="combobox"
+                value=""
+              />
+            </div>
+            <div
+              class="icon-container"
+            >
+              <svg
+                height="6"
+                role="img"
+                width="10"
+              >
+                <title>
+                  Open multi select options
+                </title>
+                <use
+                  xlink:href="#caret-down.svg"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`<MultiAutocompleter> has defaults 2`] = `
+Object {
+  "dirty": false,
+  "id": "test-id",
+  "name": "field-id",
+  "value": Array [],
+}
+`;

--- a/src/components/multi-autocompleter/multi-autocompleter.jsx
+++ b/src/components/multi-autocompleter/multi-autocompleter.jsx
@@ -1,0 +1,90 @@
+import PropTypes from 'prop-types';
+import React, { forwardRef, useEffect, useState } from 'react';
+import useFetch from '@bloodyaugust/use-fetch';
+import MultiSelect from '../multi-select/multi-select.jsx';
+import mockConstants from '../../mocks/mock-constants.js';
+
+const { API_ROOT } = mockConstants;
+
+const MultiAutocompleter = forwardRef(function MultiAutocompleter(props, ref) {
+  const { execute } = useFetch();
+  const [loading, setLoading] = useState(false);
+  const [options, setOptions] = useState([]);
+  const [value, setValue] = useState(props.value || []);
+
+  function fetchOptions() {
+    setLoading(true);
+    execute(`${API_ROOT}${props.apiEndpoint}`)
+      .then(({ json, mounted }) => {
+        if (mounted) {
+          setOptions(json.results.map(result => json[result.key][result.id]));
+          setLoading(false);
+        }
+      }).catch((error) => {
+        if (error.error && error.error.type !== 'aborted') {
+          setLoading(false);
+          throw error;
+        }
+      });
+  }
+
+  useEffect(fetchOptions, []);
+
+  useEffect(() => {
+    setValue(props.value);
+  }, [props.value.map(val => JSON.stringify(val)).join(',')]);
+
+  return (
+    <MultiSelect
+      classNames={{
+        container: props.className,
+      }}
+      id={props.id}
+      label={props.label}
+      name={props.name}
+      onChange={props.onChange}
+      options={options}
+      optionIDGetter={option => option.id}
+      optionLabelGetter={option => option.name}
+      placeholder={props.placeholder}
+      readOnly={props.readOnly}
+      ref={ref}
+      required={props.required}
+      showLoader={loading}
+      validationMessage={props.validationMessage}
+      value={value}
+    />
+  );
+});
+
+MultiAutocompleter.propTypes = {
+  // `apiEndpoint` should be the route of the api's endpoint (excluding the base api), eg. `/workspaces`.
+  apiEndpoint: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
+  required: PropTypes.bool,
+  searchParam: PropTypes.string,
+  validationMessage: PropTypes.string,
+  // `value` shape is expected to be a collection objects with an `id` key
+  value: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.required,
+  })),
+};
+
+MultiAutocompleter.defaultProps = {
+  className: undefined,
+  onChange: () => { },
+  placeholder: undefined,
+  readOnly: false,
+  required: false,
+  searchParam: 'search',
+  validationMessage: undefined,
+  value: [],
+};
+
+export default MultiAutocompleter;

--- a/src/components/multi-autocompleter/multi-autocompleter.md
+++ b/src/components/multi-autocompleter/multi-autocompleter.md
@@ -1,0 +1,13 @@
+## Ref API Example
+```jsx
+import MultiAutocompleter from './multi-autocompleter.jsx';
+import RefExample from '@mavenlink/design-system/src/components/ref-example/ref-example.jsx';
+
+const ref = React.createRef();
+
+<RefExample ref={ref}>
+  {({ onChange }) => (
+    <MultiAutocompleter ref={ref} onChange={onChange} apiEndpoint='/models' id='ex-1' name='ref-ex' label='Ref Example'  />
+  )}
+</RefExample>
+```

--- a/src/components/multi-autocompleter/multi-select.test.jsx
+++ b/src/components/multi-autocompleter/multi-select.test.jsx
@@ -1,0 +1,22 @@
+import React, { createRef } from 'react';
+import {
+  render,
+} from '@testing-library/react';
+import MultiAutocompleter from './multi-autocompleter.jsx';
+
+describe('<MultiAutocompleter>', () => {
+  const requiredProps = {
+    apiEndpoint: '/models',
+    id: 'test-id',
+    label: 'test label',
+    name: 'field-id',
+  };
+
+  it('has defaults', () => {
+    const ref = createRef();
+
+    render(<MultiAutocompleter {...requiredProps} ref={ref} />);
+    expect(document.body).toMatchSnapshot();
+    expect(ref.current).toMatchSnapshot();
+  });
+});

--- a/src/components/multi-select/__snapshots__/multi-select.test.jsx.snap
+++ b/src/components/multi-select/__snapshots__/multi-select.test.jsx.snap
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<MultiSelect> has defaults 1`] = `
+<body>
+  <div>
+    <div
+      class="container"
+      id="test-id"
+    >
+      <div
+        role="presentation"
+      >
+        <label
+          class="label"
+          for="test-id-autocomplete"
+          id="test-id-label"
+        >
+          test label
+        </label>
+        <div
+          class="control-container"
+        >
+          <div
+            class="form-control-children-container"
+            role="presentation"
+          >
+            <div
+              aria-labelledby="test-id-label"
+              class="tag-list"
+              role="grid"
+            >
+              <input
+                aria-autocomplete="list"
+                aria-controls="test-id-listbox"
+                aria-describedby="test-id-empty"
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-labelledby="test-id-label"
+                autocomplete="off"
+                class="input"
+                id="test-id-autocomplete"
+                role="combobox"
+                value=""
+              />
+            </div>
+            <div
+              class="icon-container"
+            >
+              <svg
+                height="6"
+                role="img"
+                width="10"
+              >
+                <title>
+                  Open multi select options
+                </title>
+                <use
+                  xlink:href="#caret-down.svg"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`<MultiSelect> has defaults 2`] = `
+Object {
+  "dirty": false,
+  "id": "test-id",
+  "name": "field-id",
+  "value": Array [],
+}
+`;

--- a/src/components/multi-select/multi-select.css
+++ b/src/components/multi-select/multi-select.css
@@ -1,0 +1,80 @@
+@import '../../styles/colors-v2.css';
+@import '../../styles/spacing.css';
+
+.container {
+  composes: tag-list from '../tag-list/tag-list.css';
+  composes: input-container from '../__internal__/abstract-custom-field/abstract-custom-field.css';
+  height: auto;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.icon-clear {
+  cursor: pointer;
+  padding: var(--spacing-small);
+}
+
+.icon-clear-readonly {
+  composes: icon-clear;
+  cursor: unset;
+  pointer-events: none;
+}
+
+.icon-container {
+  composes: icons from '../form-control-icons/form-control-icons.css';
+  top: calc(var(--spacing-large) + var(--spacing-small));
+}
+
+.input {
+  border: none;
+  flex-grow: 1;
+  flex-shrink: 1;
+  height: var(--spacing-x-large);
+  width: 0;
+}
+
+.input-readonly {
+  composes: input;
+  background-color: transparent;
+}
+
+.form-control-children-container {
+  composes: input-styles from '../__internal__/abstract-custom-field/abstract-custom-field.css';
+  align-items: center;
+  height: auto;
+  padding-right: calc(var(--spacing-x-large) + var(--spacing-medium));
+}
+
+.form-control-children-container-readonly {
+  composes: form-control-children-container;
+  background-color: var(--mds-grey-3);
+}
+
+.popup-container {
+  composes: container from '../listbox/listbox.css';
+  background-color: var(--white);
+  box-sizing: border-box;
+  max-height: 160px;
+  overflow-y: scroll;
+  position: absolute;
+  width: 100%;
+  z-index: 10;
+}
+
+.no-options {
+  composes: popup-container;
+  composes: no-options from '../no-options/no-options.css';
+  color: var(--mds-grey-54);
+  display: flex;
+  justify-content: center;
+  overflow-y: unset;
+}
+
+.tag-list {
+  composes: tag-list from '../tag-list/tag-list.css';
+  align-items: center;
+  display: flex;
+  flex-grow: 1;
+  flex-wrap: wrap;
+  min-height: var(--spacing-x-large);
+}

--- a/src/components/multi-select/multi-select.jsx
+++ b/src/components/multi-select/multi-select.jsx
@@ -117,11 +117,6 @@ const MultiSelect = forwardRef(function MultiSelect(props, ref) {
       }));
   }
 
-  const handleDropdownClose = () => {
-    setExpanded(false);
-    setAutocompleteValue('');
-  };
-
   function onAutocompleteBlur() {
     if (!autocompleteRef.current) return;
 
@@ -136,6 +131,11 @@ const MultiSelect = forwardRef(function MultiSelect(props, ref) {
   function onAutocompleteChange(event) {
     setExpanded(true);
     setAutocompleteValue(event.target.value);
+  }
+
+  function onDropdownClose() {
+    setExpanded(false);
+    setAutocompleteValue('');
   }
 
   function onOptionRemove(event) {
@@ -182,7 +182,7 @@ const MultiSelect = forwardRef(function MultiSelect(props, ref) {
     }
   }
 
-  useDropdownClose(wrapperRef, expanded, handleDropdownClose);
+  useDropdownClose(wrapperRef, expanded, onDropdownClose);
 
   useEffect(() => {
     setValue(props.value);

--- a/src/components/multi-select/multi-select.jsx
+++ b/src/components/multi-select/multi-select.jsx
@@ -1,0 +1,316 @@
+import React, {
+  createRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  forwardRef,
+} from 'react';
+import PropTypes from 'prop-types';
+import FormControl from '../form-control/form-control.jsx';
+import FormControlIcons from '../form-control-icons/form-control-icons.jsx';
+import Icon from '../icon/icon.jsx';
+import IconButton from '../icon-button/icon-button.jsx';
+import iconCaretDown from '../../svgs/caret-down.svg';
+import iconClear from '../../svgs/clear.svg';
+import Listbox from '../listbox/listbox.jsx';
+import ListOption from '../list-option/list-option.jsx';
+import Loader from '../loader/loader.jsx';
+import NoOptions from '../no-options/no-options.jsx';
+import TagList from '../tag-list/tag-list.jsx';
+import Tag from '../tag/tag.jsx';
+import useDropdownClose from '../../hooks/use-dropdown-close.js';
+import styles from './multi-select.css';
+
+const MultiSelect = forwardRef(function MultiSelect(props, ref) {
+  const [autocompleteValue, setAutocompleteValue] = useState('');
+  const autocompleteRef = useRef();
+  const backupRef = useRef();
+  const [expanded, setExpanded] = useState(false);
+  const selfRef = ref || backupRef;
+  const [validationMessage, setValidationMessage] = useState(props.validationMessage);
+  const [value, setValue] = useState(props.value || []);
+  const valueRefs = value.map(() => createRef());
+  const visibleOptions = getVisibleOptions();
+  const visibleOptionsRefs = visibleOptions.map(() => createRef());
+  const wrapperRef = useRef(null);
+
+  const ids = {
+    emptyMessage: `${props.id}-empty`,
+    label: `${props.id}-label`,
+    listbox: `${props.id}-listbox`,
+    textbox: `${props.id}-autocomplete`,
+  };
+
+  const classNames = {
+    container: styles.container,
+    formControlChildrenContainer: props.readOnly ? styles['form-control-children-container-readonly'] : styles['form-control-children-container'],
+    iconClear: props.readOnly ? styles['icon-clear-readonly'] : styles['icon-clear'],
+    iconsContainer: styles['icon-container'],
+    input: props.readOnly ? styles['input-readonly'] : styles.input,
+    noOptionsContainer: styles['no-options'],
+    popupContainer: styles['popup-container'],
+    tagList: styles['tag-list'],
+    ...props.classNames,
+  };
+
+  const dropdownContents = () => {
+    if (!expanded) {
+      return undefined;
+    }
+
+    if (props.showLoader) {
+      return (
+        <Listbox
+          className={classNames.popupContainer}
+          id={ids.listbox}
+          labelledBy={ids.label}
+          refs={[]}
+        >
+          <Loader inline />
+        </Listbox>
+      );
+    }
+
+    if (visibleOptions.length === 0) {
+      return (<NoOptions className={classNames.noOptionsContainer} id={ids.emptyMessage} />);
+    }
+
+    return (
+      <Listbox
+        className={classNames.popupContainer}
+        id={ids.listbox}
+        labelledBy={ids.label}
+        refs={visibleOptionsRefs}
+      >
+        {props.listboxChildren ?
+          props.listboxChildren(visibleOptions, visibleOptionsRefs, onOptionSelect) :
+          visibleOptions.map((option, index) => (
+            <ListOption
+              key={`${props.id}-${props.optionIDGetter(option)}`}
+              onSelect={onOptionSelect}
+              ref={visibleOptionsRefs[index]}
+              value={props.optionIDGetter(option)}
+            >
+              {props.optionLabelGetter(option)}
+            </ListOption>
+          ))}
+      </Listbox>
+    );
+  };
+
+  function getOption(id) {
+    return props.options.find(option => props.optionIDGetter(option) === id);
+  }
+
+  function getVisibleOptions() {
+    return props.options
+      .filter(option => props.optionLabelGetter(option).toLowerCase().includes(autocompleteValue.toLowerCase()))
+      .filter(option => !value.some((val) => {
+        const optionID = props.optionIDGetter(option);
+
+        if (typeof optionID === 'string') {
+          return val.toLowerCase() === optionID.toLowerCase();
+        }
+
+        return val === optionID;
+      }));
+  }
+
+  const handleDropdownClose = () => {
+    setExpanded(false);
+    setAutocompleteValue('');
+  };
+
+  function onAutocompleteBlur() {
+    if (!autocompleteRef.current) return;
+
+    autocompleteRef.current.setCustomValidity('');
+    if (!autocompleteRef.current.validity.valid) {
+      setValidationMessage(autocompleteRef.current.validationMessage);
+    } else {
+      setValidationMessage(props.validationMessage || '');
+    }
+  }
+
+  function onAutocompleteChange(event) {
+    setExpanded(true);
+    setAutocompleteValue(event.target.value);
+  }
+
+  function onOptionRemove(event) {
+    const newValue = value.filter((option, index) => (
+      valueRefs[index].current !== event.target
+    ));
+    setValue(newValue);
+  }
+
+  function onOptionsClear(event) {
+    event.preventDefault();
+
+    if (!props.readOnly) {
+      setValue([]);
+      setExpanded(false);
+      autocompleteRef.current.focus();
+    }
+  }
+
+  function onOptionSelect(event) {
+    const selectedOptionIndex = visibleOptionsRefs.findIndex(optionRef => optionRef === event.target);
+    const selectedOption = visibleOptions[selectedOptionIndex];
+    setExpanded(false);
+    const newValue = [...value, props.optionIDGetter(selectedOption)]
+      .sort((a, b) => props.optionIDGetter(a) - props.optionIDGetter(b));
+    setValue(newValue);
+    setAutocompleteValue('');
+    autocompleteRef.current.focus();
+  }
+
+  function onClick(event) {
+    if (event.defaultPrevented) return;
+    if (props.readOnly) return;
+
+    setExpanded(true);
+  }
+
+  function onKeyDown(event) {
+    switch (event.key) {
+      case 'Escape':
+        setExpanded(false);
+        break;
+      default:
+    }
+  }
+
+  useDropdownClose(wrapperRef, expanded, handleDropdownClose);
+
+  useEffect(() => {
+    setValue(props.value);
+  }, [props.value.map(val => JSON.stringify(val)).join(',')]);
+
+  useEffect(() => {
+    props.onChange({ target: selfRef.current });
+  }, [value.map(val => JSON.stringify(val)).join(',')]);
+
+  useImperativeHandle(selfRef, () => ({
+    get dirty() {
+      return props.value.map(val => JSON.stringify(val)).join(',') !== this.value.map(val => JSON.stringify(val)).join(',');
+    },
+    id: props.id,
+    name: props.name,
+    get value() {
+      return value;
+    },
+  }));
+
+  return (
+    <div className={classNames.container} id={props.id} ref={wrapperRef}>
+      <FormControl
+        label={props.label}
+        labelId={ids.label}
+        id={ids.textbox}
+        error={validationMessage}
+        onKeyDown={onKeyDown}
+      >
+        <div role="presentation" className={classNames.formControlChildrenContainer} onClick={onClick}>
+          <TagList
+            className={classNames.tagList}
+            labelledBy={ids.label}
+            refs={valueRefs}
+          >
+            {value.length !== 0 &&
+              props.tagChildren ?
+              props.tagChildren(value, valueRefs, onOptionRemove) :
+              value.map((val, index) => (
+                <Tag
+                  defaultActive={index === 0}
+                  id={`${props.id}-option-${props.optionIDGetter(getOption(val))}`}
+                  key={props.optionIDGetter(getOption(val))}
+                  onRemove={onOptionRemove}
+                  readOnly={props.readOnly}
+                  ref={valueRefs[index]}
+                >
+                  {props.optionLabelGetter(
+                    props.options.find(option => props.optionIDGetter(option) === props.optionIDGetter(getOption(val))),
+                  )}
+                </Tag>
+              ))
+            }
+            <input
+              aria-autocomplete="list"
+              aria-controls={ids.listbox}
+              aria-describedby={`${ids.emptyMessage}`}
+              aria-expanded={expanded}
+              aria-haspopup="listbox"
+              aria-labelledby={ids.label}
+              autoComplete="off"
+              role="combobox"
+              className={classNames.input}
+              id={ids.textbox}
+              onBlur={onAutocompleteBlur}
+              onChange={onAutocompleteChange}
+              placeholder={value.length === 0 ? props.placeholder : undefined}
+              readOnly={props.readOnly}
+              required={props.required ? value.length === 0 : false}
+              ref={autocompleteRef}
+              value={autocompleteValue}
+            />
+          </TagList>
+          <FormControlIcons validationMessage={props.validationMessage} className={classNames.iconsContainer}>
+            {value.length > 0 && (
+              <IconButton
+                icon={iconClear}
+                label={`Remove all selected options on ${props.label}`}
+                onPress={onOptionsClear}
+                className={classNames.iconClear}
+              />
+            )}
+            <Icon icon={iconCaretDown} label="Open multi select options" />
+          </FormControlIcons>
+        </div>
+        {dropdownContents()}
+      </FormControl>
+    </div>
+  );
+});
+
+MultiSelect.propTypes = {
+  classNames: PropTypes.shape({
+    container: PropTypes.string,
+    formControlChildrenContainer: PropTypes.string,
+    input: PropTypes.string,
+    tagList: PropTypes.string,
+  }),
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  listboxChildren: PropTypes.func, // eslint-disable-line react/no-unused-prop-types
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  options: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.arrayOf(PropTypes.string)]).isRequired,
+  optionIDGetter: PropTypes.func,
+  optionLabelGetter: PropTypes.func,
+  placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
+  required: PropTypes.bool,
+  showLoader: PropTypes.bool, // eslint-disable-line react/no-unused-prop-types
+  tagChildren: PropTypes.func,
+  validationMessage: PropTypes.string,
+  value: PropTypes.arrayOf(PropTypes.string),
+};
+
+MultiSelect.defaultProps = {
+  classNames: {},
+  listboxChildren: undefined,
+  onChange: () => { },
+  optionIDGetter: option => option,
+  optionLabelGetter: option => option,
+  placeholder: undefined,
+  readOnly: false,
+  required: false,
+  showLoader: false,
+  tagChildren: undefined,
+  value: [],
+  validationMessage: undefined,
+};
+
+export default MultiSelect;

--- a/src/components/multi-select/multi-select.md
+++ b/src/components/multi-select/multi-select.md
@@ -1,0 +1,163 @@
+`MultiSelect` allows for the selection of multiple values in an accessible, searchable interface. It also provides flexibility in how you render selected options and options in the dropdown, but the default is MDS compatible and assured.
+
+## Basic Usage
+```jsx
+import MultiSelect from '@mavenlink/design-system/src/components/multi-select/multi-select.jsx';
+
+<MultiSelect
+  id="example-1"
+  label="Basic MultiSelect"
+  name="example"
+  options={['Option 1', 'Option 2', 'Option 3']}
+  placeholder="Select some options"
+/>
+```
+
+## Required
+```jsx
+import MultiSelect from '@mavenlink/design-system/src/components/multi-select/multi-select.jsx';
+
+<MultiSelect
+  id="example-2"
+  label="Required MultiSelect"
+  name="example"
+  options={['Option 1', 'Option 2', 'Option 3']}
+  required
+/>
+```
+
+## Readonly
+```jsx
+import MultiSelect from '@mavenlink/design-system/src/components/multi-select/multi-select.jsx';
+
+<MultiSelect
+  id="example-3"
+  label="Readonly MultiSelect"
+  name="example"
+  options={['Option 1', 'Option 2', 'Option 3']}
+  value={['Option 1', 'Option 2']}
+  readOnly
+/>
+```
+
+## Object Options
+```jsx
+import MultiSelect from '@mavenlink/design-system/src/components/multi-select/multi-select.jsx';
+
+const options = [
+  {
+    id: '0',
+    text: 'Hello'
+  },
+  {
+    id: '1',
+    text: 'World!'
+  },
+];
+
+<MultiSelect
+  id="example-4"
+  label="MultiSelect with Object Options"
+  name="example"
+  options={options}
+  optionIDGetter={option => option.id}
+  optionLabelGetter={option => option.text}
+/>
+```
+
+## Loader
+```jsx
+import MultiSelect from '@mavenlink/design-system/src/components/multi-select/multi-select.jsx';
+
+<MultiSelect
+  id="example-5"
+  label="Loader MultiSelect"
+  name="example"
+  options={['Option 1', 'Option 2', 'Option 3']}
+  value={['Option 1', 'Option 2']}
+  showLoader
+/>
+```
+
+## Custom Listbox and TagList Children
+With the `listboxChildren` and `tagChildren` props, you can provide your own function for rendering both the dropdown options and the selected values. While the `Listbox` has very few requirements for its children, `TagList` has a few more necessary from the `ref` API of its children. Either use `Tag` compositionally as we do here, or implement the same `ref` API in your own component.
+
+```jsx
+import MultiSelect from '@mavenlink/design-system/src/components/multi-select/multi-select.jsx';
+import Tag from '@mavenlink/design-system/src/components/tag/tag.jsx';
+
+const ListboxChild = React.forwardRef((props, ref) => {
+  return (
+    <div ref={ref} onClick={() => { props.onOptionSelect({ target: ref }) }}>{props.option}</div>
+  )
+});
+
+const TagChild = React.forwardRef((props, ref) => {
+  return (
+    <div>
+      <span>Some Custom Text</span>
+      <Tag
+        defaultActive={props.index === 0}
+        id={props.val}
+        key={props.val}
+        onRemove={props.onOptionRemove}
+        ref={ref}
+      >
+        {props.val}
+      </Tag>
+    </div>
+  )
+});
+
+const listboxChildren = (visibleOptions, refs, onOptionSelect) => {
+  return (
+    <div>
+      {visibleOptions.map((option, index) => (
+        <ListboxChild key={option} option={option} onOptionSelect={onOptionSelect} ref={refs[index]} />
+      ))}
+    </div>
+  )
+}
+
+const tagChildren = (values, refs, onOptionRemove) => {
+  return (
+    <React.Fragment>
+      {values.map((val, index) => (
+        <TagChild key={val} index={index} onOptionRemove={onOptionRemove} val={val} ref={refs[index]} />
+      ))}
+    </React.Fragment>
+  )
+}
+
+<MultiSelect
+  id="example-5"
+  label="MultiSelect with Custom Children"
+  name="example"
+  options={['Option 1', 'Option 2', 'Option 3']}
+  listboxChildren={listboxChildren}
+  tagChildren={tagChildren}
+/>
+```
+
+## Ref API Example
+
+```jsx
+import MultiSelect from '@mavenlink/design-system/src/components/multi-select/multi-select.jsx';
+import RefExample from '@mavenlink/design-system/src/components/ref-example/ref-example.jsx';
+
+const ref = React.createRef();
+
+<RefExample ref={ref}>
+  {({ onChange }) => (
+    <MultiSelect
+      options={['Test 1', 'Test 2', 'Test 3', 'Test 4', 'Test 5', 'Test 6', 'Test 7', 'Test 8', 'Test 9', 'Test 10', 'Test 11', 'Test 12', 'Test 13', 'Test 14', 'Test 15', 'Test 16', 'Test 17', 'Test 18', 'Test 19', 'Test 20', 'Test 79163871268371687326137812763818894792384723978',]}
+      id="example-1"
+      label="Example multi select"
+      name="example"
+      onChange={onChange}
+      ref={ref}
+      value={['Test 1', 'Test 2',]}
+    />
+  )}
+</RefExample>
+```

--- a/src/components/multi-select/multi-select.test.jsx
+++ b/src/components/multi-select/multi-select.test.jsx
@@ -1,0 +1,500 @@
+import React, { createRef } from 'react';
+import {
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MultiSelect from './multi-select.jsx';
+import Tag from '../tag/tag.jsx';
+import {
+  getAutocompleter,
+  getAvailableOption,
+  getRemoveButton,
+  getSelectedOption,
+  openOptions,
+  queryAvailableOption,
+  querySelectedOption,
+  queryRemoveButton,
+} from './test-queries.js';
+
+describe('<MultiSelect>', () => {
+  const requiredProps = {
+    options: ['Foo', 'Bar'],
+    id: 'test-id',
+    label: 'test label',
+    name: 'field-id',
+  };
+
+  it('has defaults', () => {
+    const ref = createRef();
+
+    render(<MultiSelect {...requiredProps} ref={ref} />);
+    expect(document.body).toMatchSnapshot();
+    expect(ref.current).toMatchSnapshot();
+  });
+
+  describe('classNames API', () => {
+    it('uses class name overrides provided', () => {
+      render(<MultiSelect
+        {...requiredProps}
+        classNames={{
+          container: 'unique-container',
+          formControlChildrenContainer: 'unique-form-control-children-container',
+          input: 'unique-input-class',
+          tagList: 'unique-tag-list-class',
+        }}
+      />);
+
+      expect(document.querySelector('.unique-container')).toBeInTheDocument();
+      expect(document.querySelector('.unique-form-control-children-container')).toBeInTheDocument();
+      expect(document.querySelector('.unique-input-class')).toBeInTheDocument();
+      expect(document.querySelector('.unique-tag-list-class')).toBeInTheDocument();
+    });
+  });
+
+  describe('id API', () => {
+    it('sets id of container and selected options', () => {
+      render(<MultiSelect {...requiredProps} id="unique-id" value={['Foo']} />);
+
+      expect(document.querySelector('#unique-id')).toBeInTheDocument();
+      expect(getSelectedOption('test label', 'Foo').parentElement).toHaveAttribute('id', 'unique-id-option-Foo');
+    });
+  });
+
+  describe('label API', () => {
+    it('sets label of form control and clear button', () => {
+      render(<MultiSelect {...requiredProps} label="unique label" value={['Foo']} />);
+
+      expect(screen.getByText('unique label')).toBeInTheDocument();
+      expect(getRemoveButton('unique label', 'Foo')).toBeInTheDocument();
+    });
+  });
+
+  describe('listboxChildren API', () => {
+    it('uses render function for listbox children if set', () => {
+      function listboxChildren(options, refs, onSelect) {
+        return (
+          <div>
+            {options.map((option, index) => (
+              <span key={option} ref={refs[index]} onClick={() => { onSelect({ target: refs[index] }); }}>Override {option}</span>
+            ))}
+          </div>
+        );
+      }
+
+      render(<MultiSelect {...requiredProps} listboxChildren={listboxChildren} />);
+
+      openOptions('test label');
+      expect(screen.getByText('Override Foo')).toBeInTheDocument();
+      userEvent.click(screen.getByText('Override Foo'));
+      expect(getSelectedOption('test label', 'Foo')).toBeInTheDocument();
+    });
+  });
+
+  describe('onChange API', () => {
+    it('fires the onChange event when the value changes', () => {
+      let value = [];
+
+      function onChange(event) {
+        value = event.target.value;
+      }
+
+      render(<MultiSelect {...requiredProps} onChange={onChange} />);
+
+      openOptions('test label');
+      userEvent.click(getAvailableOption('test label', 'Foo'));
+      expect(value).toContain('Foo');
+    });
+  });
+
+  describe('options API', () => {
+    it('generates options', () => {
+      render(<MultiSelect {...requiredProps} />);
+
+      openOptions('test label');
+      expect(getAvailableOption('test label', 'Foo')).toBeInTheDocument();
+      expect(getAvailableOption('test label', 'Bar')).toBeInTheDocument();
+    });
+  });
+
+  describe('option objects APIs', () => {
+    it('allows option that are objects, and uses provided getters', () => {
+      render(<MultiSelect
+        {...requiredProps}
+        options={[
+          {
+            id: 'test-1',
+            label: 'Foo',
+          },
+          {
+            id: 'test-2',
+            label: 'Bar',
+          },
+        ]}
+        optionIDGetter={option => option.id}
+        optionLabelGetter={option => option.label}
+      />);
+
+      openOptions('test label');
+
+      expect(getAvailableOption('test label', 'Foo')).toBeInTheDocument();
+      expect(getAvailableOption('test label', 'Bar')).toBeInTheDocument();
+
+      userEvent.type(document.activeElement, 'F');
+
+      expect(getAvailableOption('test label', 'Foo')).toBeInTheDocument();
+      expect(queryAvailableOption('test label', 'Bar')).not.toBeInTheDocument();
+
+      userEvent.click(getAvailableOption('test label', 'Foo'));
+
+      expect(getSelectedOption('test label', 'Foo')).toBeInTheDocument();
+    });
+  });
+
+  describe('placeholder API', () => {
+    it('sets the autocompleter placeholder', () => {
+      render(<MultiSelect {...requiredProps} placeholder="This is a placeholder" />);
+
+      expect(getAutocompleter('test label')).toHaveAttribute('placeholder', 'This is a placeholder');
+    });
+  });
+
+  describe('readOnly API', () => {
+    it('can be set to `true`', () => {
+      render((<MultiSelect
+        {...requiredProps}
+        readOnly={true}
+      />));
+
+      expect(getAutocompleter('test label')).toHaveAttribute('readOnly', '');
+      expect(queryRemoveButton('test label')).not.toBeInTheDocument();
+      userEvent.click(getAutocompleter('test label'));
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('can be set to `false`', () => {
+      render((<MultiSelect
+        {...requiredProps}
+        readOnly={false}
+        value={['Foo']}
+      />));
+
+      expect(getSelectedOption('test label', 'Foo')).toBeInTheDocument();
+      expect(getAutocompleter('test label')).not.toHaveAttribute('readOnly', '');
+      expect(screen.getByRole('button', { name: 'Remove Foo' })).toBeInTheDocument();
+    });
+  });
+
+  describe('required API', () => {
+    it('can be set to `true`', () => {
+      render((<MultiSelect
+        {...requiredProps}
+        required={true}
+      />));
+
+      expect(getAutocompleter('test label')).toHaveAttribute('required', '');
+      expect(getAutocompleter('test label')).toBeInvalid();
+      openOptions('test label');
+      userEvent.click(getAutocompleter('test label'));
+      userEvent.tab();
+      expect(getAutocompleter('test label')).toBeInvalid();
+      userEvent.click(getAutocompleter('test label'));
+      userEvent.click(getAvailableOption('test label', 'Foo'));
+      expect(getAutocompleter('test label')).toBeValid();
+    });
+
+    it('can be set to `false`', () => {
+      render((<MultiSelect
+        {...requiredProps}
+        readOnly={false}
+        value={['Foo']}
+      />));
+
+      expect(getSelectedOption('test label', 'Foo')).toBeInTheDocument();
+      expect(getAutocompleter('test label')).not.toHaveAttribute('required');
+      expect(getAutocompleter('test label')).toBeValid();
+      expect(getAutocompleter('test label')).not.toHaveDescription('Constraints not satisfied');
+      userEvent.click(getAutocompleter('test label'));
+      userEvent.tab();
+      expect(getAutocompleter('test label')).not.toHaveDescription('Constraints not satisfied');
+    });
+  });
+
+  describe('showLoader API', () => {
+    it('when set to true, shows a loader in the autocompleter dropdown', () => {
+      render(<MultiSelect {...requiredProps} showLoader />);
+
+      openOptions('test label');
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    it('when set to false, shows no loader', () => {
+      render(<MultiSelect {...requiredProps} showLoader={false} />);
+
+      openOptions('test label');
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('tagChildren API', () => {
+    it('uses render function for taglist children if set', () => {
+      function tagChildren(options, refs, onRemove) {
+        return (
+          <div>
+            {options.map((option, index) => (
+              <React.Fragment key={option}>
+                <span>Override {option}</span>
+                <Tag
+                  defaultActive={index === 0}
+                  id={option}
+                  key={option}
+                  onRemove={onRemove}
+                  ref={refs[index]}
+                >
+                  {option}
+                </Tag>
+              </React.Fragment>
+            ))}
+          </div>
+        );
+      }
+
+      render(<MultiSelect {...requiredProps} tagChildren={tagChildren} value={['Foo']} />);
+
+      expect(screen.getByText('Override Foo')).toBeInTheDocument();
+      expect(getSelectedOption('test label', 'Foo')).toBeInTheDocument();
+      userEvent.click(getRemoveButton('test label', 'Foo'));
+      expect(querySelectedOption('test label', 'Foo')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('validationMessage API', () => {
+    it('sets the validationMessage on the form control', () => {
+      const { rerender } = render(<MultiSelect {...requiredProps} validationMessage="Some backend error" />);
+
+      expect(screen.getByText('Some backend error', { selector: 'span' })).toBeInTheDocument();
+      rerender(<MultiSelect {...requiredProps} validationMessage={undefined} />);
+      expect(screen.queryByText('Some backend error', { selector: 'span' })).toBeInTheDocument();
+    });
+  });
+
+  describe('value API', () => {
+    it('sets the value for the input and is responsive to changes', () => {
+      const { rerender } = render(<MultiSelect {...requiredProps} value={['Foo']} />);
+
+      expect(getSelectedOption('test label', 'Foo')).toBeInTheDocument();
+      expect(querySelectedOption('test label', 'Bar')).not.toBeInTheDocument();
+
+      rerender(<MultiSelect {...requiredProps} value={['Bar']} />);
+      expect(querySelectedOption('test label', 'Foo')).not.toBeInTheDocument();
+      expect(getSelectedOption('test label', 'Bar')).toBeInTheDocument();
+
+      rerender(<MultiSelect {...requiredProps} value={[]} />);
+      expect(querySelectedOption('test label', 'Foo')).not.toBeInTheDocument();
+      expect(querySelectedOption('test label', 'Bar')).not.toBeInTheDocument();
+
+      rerender(<MultiSelect {...requiredProps} value={undefined} />);
+      expect(querySelectedOption('test label', 'Foo')).not.toBeInTheDocument();
+      expect(querySelectedOption('test label', 'Bar')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('autocomplete behavior', () => {
+    it('focuses the input on click', () => {
+      render(<MultiSelect {...requiredProps} />);
+      openOptions('test label');
+      expect(getAutocompleter('test label')).toHaveFocus();
+    });
+
+    it('filters visible options on autocompleter value', () => {
+      render(<MultiSelect {...requiredProps} />);
+      openOptions('test label');
+      expect(getAvailableOption('test label', 'Foo')).toBeInTheDocument();
+      expect(getAvailableOption('test label', 'Bar')).toBeInTheDocument();
+      userEvent.type(document.activeElement, 'F');
+      expect(getAvailableOption('test label', 'Foo')).toBeInTheDocument();
+      expect(queryAvailableOption('test label', 'Bar')).not.toBeInTheDocument();
+    });
+
+    it('clears the autocompleter on selection', () => {
+      render(<MultiSelect {...requiredProps} />);
+      userEvent.type(getAutocompleter('test label'), 'F');
+      userEvent.click(getAvailableOption('test label', 'Foo'));
+      expect(getAutocompleter('test label')).toHaveValue('');
+    });
+
+    it('opens on typing', async () => {
+      render(<MultiSelect {...requiredProps} />);
+      userEvent.tab();
+      expect(getAutocompleter('test label')).toHaveFocus();
+      expect(getAutocompleter('test label')).toHaveAttribute('aria-expanded', 'false');
+      await userEvent.type(getAutocompleter('test label'), 'Fo', { skipClick: true });
+      expect(getAvailableOption('test label', 'Foo')).toBeInTheDocument();
+    });
+
+    it('closes on escape key', () => {
+      render(<MultiSelect {...requiredProps} />);
+      userEvent.click(getAutocompleter('test label'));
+      expect(getAutocompleter('test label')).toHaveAttribute('aria-expanded', 'true');
+      userEvent.type(document.activeElement, '{esc}');
+      expect(getAutocompleter('test label')).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('informs the user when no option is available', async () => {
+      render(<MultiSelect {...requiredProps} options={[]} />);
+      openOptions('test label');
+      expect(getAutocompleter('test label')).toHaveDescription('No options available.');
+    });
+  });
+
+  describe('option deselect behavior', () => {
+    it('removes the option value when pressing the remove button', () => {
+      render(<MultiSelect {...requiredProps} value={['Foo']} />);
+
+      expect(getSelectedOption('test label', 'Foo')).toBeInTheDocument();
+
+      userEvent.click(getRemoveButton('test label', 'Foo'));
+      expect(querySelectedOption('test label', 'Foo')).not.toBeInTheDocument();
+    });
+
+    it('does not expand the popup', () => {
+      render(<MultiSelect {...requiredProps} value={['Foo']} />);
+
+      expect(getSelectedOption('test label', 'Foo')).toBeInTheDocument();
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      userEvent.click(getRemoveButton('test label', 'Foo'));
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('removes all options when pressing the clear button and focuses the input', () => {
+      render(<MultiSelect {...requiredProps} value={['Foo', 'Bar']} />);
+
+      expect(getSelectedOption('test label', 'Foo')).toBeInTheDocument();
+      expect(getSelectedOption('test label', 'Bar')).toBeInTheDocument();
+      userEvent.click(getRemoveButton('test label'));
+      expect(querySelectedOption('test label', 'Foo')).not.toBeInTheDocument();
+      expect(querySelectedOption('test label', 'Bar')).not.toBeInTheDocument();
+      expect(getAutocompleter('test label')).toHaveFocus();
+    });
+  });
+
+  describe('option select behavior', () => {
+    it('removes the option from the list of options', () => {
+      render(<MultiSelect {...requiredProps} />);
+      openOptions('test label');
+      expect(screen.queryByRole('option', { name: 'Foo' })).toBeInTheDocument();
+      userEvent.click(screen.getByRole('option', { name: 'Foo' }));
+      userEvent.click(screen.getByText('test label'));
+      expect(screen.queryByRole('option', { name: 'Foo' })).not.toBeInTheDocument();
+    });
+
+    it('adds the option to the selected options and focuses the auto completer', () => {
+      render(<MultiSelect {...requiredProps} />);
+      openOptions('test label');
+      expect(screen.queryByRole('gridcell', { name: 'Foo' })).not.toBeInTheDocument();
+      userEvent.click(screen.queryByRole('option', { name: 'Foo' }));
+      expect(screen.queryByRole('option', { name: 'Foo' })).not.toBeInTheDocument();
+      userEvent.click(screen.getByText('test label'));
+      expect(screen.queryByRole('gridcell', { name: 'Foo' })).toBeInTheDocument();
+      expect(getAutocompleter('test label')).toHaveFocus();
+    });
+  });
+
+  describe('dropdown close behavior', () => {
+    it('closes the dropdown when clicking outside', async () => {
+      render(
+        <div>
+          <span>CLOSE</span>
+          <MultiSelect {...requiredProps} />
+        </div>,
+      );
+
+      openOptions('test label');
+      userEvent.click(getAutocompleter('test label'));
+      expect(getAvailableOption('test label', 'Foo')).toBeInTheDocument();
+      userEvent.click(screen.getByText('CLOSE'));
+      await waitFor(() => {
+        if (screen.queryByText('Foo')) throw new Error('Expected popup to be closed.');
+      });
+      expect(screen.queryByText('Foo')).not.toBeInTheDocument();
+    });
+
+    it('closes the dropdown when tabbing away', async () => {
+      render(
+        <div>
+          <MultiSelect {...requiredProps} />
+          <input />
+        </div>,
+      );
+
+      openOptions('test label');
+      userEvent.click(getAutocompleter('test label'));
+      expect(getAvailableOption('test label', 'Foo')).toBeInTheDocument();
+
+      userEvent.tab();
+      userEvent.tab();
+
+      await waitFor(() => {
+        if (screen.queryByText('Foo')) throw new Error('Expected popup to be closed.');
+      });
+      expect(screen.queryByText('Foo')).not.toBeInTheDocument();
+    });
+
+    it('resets the inputs state', async () => {
+      render(
+        <div>
+          <span>CLOSE</span>
+          <MultiSelect {...requiredProps} />
+        </div>,
+      );
+
+      openOptions('test label');
+      expect(getAutocompleter('test label')).toHaveValue('');
+      await userEvent.type(getAutocompleter('test label'), 'F');
+      expect(getAutocompleter('test label')).toHaveValue('F');
+      expect(getAvailableOption('test label', 'Foo')).toBeInTheDocument();
+      userEvent.click(screen.getByText('CLOSE'));
+
+      await waitFor(() => expect(getAutocompleter('test label')).toHaveValue(''));
+    });
+  });
+
+  describe('ref API behaviors', () => {
+    it('returns id set in props', () => {
+      const ref = createRef();
+
+      render(<MultiSelect {...requiredProps} ref={ref} id="unique-id" />);
+      expect(ref.current.id).toBe('unique-id');
+    });
+
+    it('returns name set in props', () => {
+      const ref = createRef();
+
+      render(<MultiSelect {...requiredProps} ref={ref} name="unique-name" />);
+      expect(ref.current.name).toBe('unique-name');
+    });
+
+    it('value updates through props and interaction', () => {
+      const ref = createRef();
+
+      render(<MultiSelect {...requiredProps} ref={ref} value={['Foo']} />);
+      expect(ref.current.value).toContain('Foo');
+
+      openOptions('test label');
+      userEvent.click(getAvailableOption('test label', 'Bar'));
+      expect(ref.current.value).toContain('Bar');
+    });
+
+    it('dirty updates through props and interaction', () => {
+      const ref = createRef();
+
+      render(<MultiSelect {...requiredProps} ref={ref} value={['Foo']} />);
+      expect(ref.current.dirty).toBeFalsy();
+
+      openOptions('test label');
+      userEvent.click(getAvailableOption('test label', 'Bar'));
+      expect(ref.current.dirty).toBeTruthy();
+    });
+  });
+});

--- a/src/components/multi-select/test-queries.js
+++ b/src/components/multi-select/test-queries.js
@@ -1,0 +1,50 @@
+import {
+  getByRole,
+  queryByRole,
+  screen,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+export function getAutocompleter(fieldLabel) {
+  return screen.getByRole('combobox', { name: fieldLabel });
+}
+
+export function getAvailableOption(fieldLabel, optionLabel) {
+  const listbox = screen.getByRole('listbox', { name: fieldLabel });
+  return getByRole(listbox, 'option', { name: optionLabel });
+}
+
+export function getRemoveButton(fieldLabel, optionLabel) {
+  if (optionLabel) {
+    return screen.getByRole('button', { name: `Remove ${optionLabel}` });
+  }
+
+  return screen.getByText(`Remove all selected options on ${fieldLabel}`);
+}
+
+export function getSelectedOption(fieldLabel, optionLabel) {
+  const taglist = screen.getByRole('grid', { name: fieldLabel });
+  return getByRole(taglist, 'gridcell', { name: optionLabel });
+}
+
+export function openOptions(fieldName) {
+  userEvent.click(screen.getByRole('combobox', { name: fieldName }));
+}
+
+export function queryAvailableOption(fieldLabel, optionLabel) {
+  const listbox = screen.getByRole('listbox', { name: fieldLabel });
+  return queryByRole(listbox, 'option', { name: optionLabel });
+}
+
+export function queryRemoveButton(fieldLabel, optionLabel) {
+  if (optionLabel) {
+    return screen.queryByRole('button', { name: `Remove ${optionLabel}` });
+  }
+
+  return screen.queryByText(`Remove all selected options on ${fieldLabel}`);
+}
+
+export function querySelectedOption(fieldLabel, optionLabel) {
+  const taglist = screen.getByRole('grid', { name: fieldLabel });
+  return queryByRole(taglist, 'gridcell', { name: optionLabel });
+}


### PR DESCRIPTION
## Motivation
We want smart component where it matters.

## Acceptance Criteria
- The component can be configured to fetch from a particular Mavenlink endpoint
  - API endpoint
  - Attribute that represents the display value of a result
  - Name of the search query parameter (default: `search`)
- By default (and on mount), it fetches the first unfiltered page of results
- With user typing, it fetches a filtered page of results
- When the results are empty, there is a "No results" empty message as the dropdown
- The component has a ref API that exposes the value of selected items. 
  - When something is selected, it is an array of IDs
  - When nothing is selected, it is `undefined` or empty array
- The component has a value API
  - When value is passed as a prop:
    - It fetches the selected information from the API
- Other APIs needed for custom forms:
  - label
  - required
  - readOnly
  - placeholder
  - validationMessage

## PR upkeep checklist

- [ ] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [ ] Deployment URL: https://mavenlink.github.io/design-system/$BRANCH/
- [ ] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
