### PR TITLE
fix(Autocompleter): check if its mounted before modifying state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
+  - fix(Autocompleter): check if its mounted before modifying state
 </details>
 
 ## v0.73.1

--- a/src/components/autocompleter/autocompleter.jsx
+++ b/src/components/autocompleter/autocompleter.jsx
@@ -26,7 +26,9 @@ const Autocompleter = forwardRef(function Autocompleter(props, ref) {
 
     execute(apiEndpoint(searchString))
       .then((respObj) => {
-        return setModels(respObj.json.results.map(result => respObj.json[result.key][result.id]));
+        if (mounted.current) {
+          setModels(respObj.json.results.map(result => respObj.json[result.key][result.id]));
+        }
       }).catch((error) => {
         if (error.error && error.error.type !== 'aborted') {
           throw error;


### PR DESCRIPTION
## Motivation
This was calling intermittent failures in bigmaven-jest world

## Acceptance Criteria


## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [ ] Deployment URL: https://mavenlink.github.io/design-system/$BRANCH/
- [x] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
