### PR TITLE
Add help icon / tooltip to remaining MDS form controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@
   - feat(tooltip): Initial creation / promotion of tooltip component, intended to display short help or reminder text
   - feat(help-icon): Initial creation HelpIcon component
   - Added help text icon as optional prop the following components:
-    - input
     - abstract-custom-field  
+    - input
+    - select
 </details>
 
 ## v0.75.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
   - feat(tooltip): Initial creation / promotion of tooltip component, intended to display short help or reminder text
   - feat(help-icon): Initial creation HelpIcon component
   - Added help text icon as optional prop the following components:
-    - abstract-custom-field  
+    - abstract-custom-field
+    - checkbox
     - date
     - input
     - select

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - feat(help-icon): Initial creation HelpIcon component
   - Added help text icon as optional prop the following components:
     - abstract-custom-field
+    - autocompleter
     - checkbox
     - custom-field-input-multiple-choice
     - custom-field-input-single-choice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
     - checkbox
     - date
     - input
+    - number
     - select
     - textarea
 </details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     - custom-field-input-single-choice
     - date
     - input
+    - multi-autocompleter
     - multi-select
     - number
     - select

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     - abstract-custom-field
     - autocompleter
     - checkbox
+    - custom-field-input-date
     - custom-field-input-multiple-choice
     - custom-field-input-single-choice
     - date

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     - abstract-custom-field
     - checkbox
     - custom-field-input-multiple-choice
+    - custom-field-input-single-choice
     - date
     - input
     - number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - feat(help-icon): Initial creation HelpIcon component
   - Added help text icon as optional prop the following components:
     - abstract-custom-field  
+    - date
     - input
     - select
     - textarea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     - custom-field-input-multiple-choice
     - custom-field-input-number
     - custom-field-input-single-choice
+    - custom-field-input-text
     - date
     - input
     - multi-autocompleter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     - custom-field-input-single-choice
     - date
     - input
+    - multi-select
     - number
     - select
     - textarea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@
   - fix(Autocompleter): check if its mounted before modifying state
   - feat(tooltip): Initial creation / promotion of tooltip component, intended to display short help or reminder text
   - feat(help-icon): Initial creation HelpIcon component
-  - feat(input): expose `tooltip` prop which renders a help icon next to the label if provided
+  - Added help text icon as optional prop the following components:
+    - input
+    - abstract-custom-field  
 </details>
 
 ## v0.75.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
     - multi-autocompleter
     - multi-select
     - number
+    - percentage
     - select
     - textarea
 </details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - Added help text icon as optional prop the following components:
     - abstract-custom-field
     - checkbox
+    - custom-field-input-multiple-choice
     - date
     - input
     - number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
     - checkbox
     - custom-field-input-date
     - custom-field-input-multiple-choice
+    - custom-field-input-number
     - custom-field-input-single-choice
     - date
     - input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     - abstract-custom-field  
     - input
     - select
+    - textarea
 </details>
 
 ## v0.75.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     - abstract-custom-field
     - autocompleter
     - checkbox
+    - custom-field-input-currency
     - custom-field-input-date
     - custom-field-input-multiple-choice
     - custom-field-input-number

--- a/src/components/__internal__/abstract-custom-field/abstract-custom-field.jsx
+++ b/src/components/__internal__/abstract-custom-field/abstract-custom-field.jsx
@@ -6,7 +6,13 @@ import cautionSvg from '../../../svgs/caution.svg';
 import FormControl from '../../form-control/form-control.jsx';
 
 export default function AbstractCustomField(props) {
-  const labelId = `${props.id}-label`;
+  const ids = {
+    input: props.id,
+    label: `${props.id}-label`,
+    tooltip: `${props.id}-tooltip`,
+    validation: `${props.id}Hint`,
+  };
+
   const invalidDueToProps = props.errorText.length > 0 && !props.readOnly;
 
   const numIcons = () => {
@@ -65,16 +71,12 @@ export default function AbstractCustomField(props) {
     }
   }, [props.defaultValue]);
 
-  const describedBy = [];
-  if (invalidDueToProps) describedBy.push(`${props.id}Hint`);
-  if (props.tooltip) describedBy.push(`${props.id}-tooltip`);
-
   return (
     <FormControl
       className={props.className}
       error={props.errorText}
-      id={props.id}
-      labelId={labelId}
+      id={ids.input}
+      labelId={ids.label}
       label={props.label}
       readOnly={props.readOnly}
       required={props.required}
@@ -87,11 +89,11 @@ export default function AbstractCustomField(props) {
         aria-haspopup={props.ariaProps.haspopup}
         aria-expanded={props.ariaProps.expanded}
         aria-invalid={invalidDueToProps ? 'true' : undefined}
-        aria-describedby={describedBy.join(' ')}
+        aria-describedby={`${ids.tooltip} ${ids.validation}`}
         defaultValue={props.defaultValue}
         className={inputClassName()}
         disabled={props.disabled}
-        id={props.id}
+        id={ids.input}
         role={props.inputRole}
         max={props.max}
         maxLength={props.maxLength}

--- a/src/components/__internal__/abstract-custom-field/abstract-custom-field.jsx
+++ b/src/components/__internal__/abstract-custom-field/abstract-custom-field.jsx
@@ -65,6 +65,10 @@ export default function AbstractCustomField(props) {
     }
   }, [props.defaultValue]);
 
+  const describedBy = [];
+  if (invalidDueToProps) describedBy.push(`${props.id}Hint`);
+  if (props.tooltip) describedBy.push(`${props.id}-tooltip`);
+
   return (
     <FormControl
       className={props.className}
@@ -74,6 +78,7 @@ export default function AbstractCustomField(props) {
       label={props.label}
       readOnly={props.readOnly}
       required={props.required}
+      tooltip={props.tooltip}
     >
       <input
         autoComplete={props.autoComplete}
@@ -82,7 +87,7 @@ export default function AbstractCustomField(props) {
         aria-haspopup={props.ariaProps.haspopup}
         aria-expanded={props.ariaProps.expanded}
         aria-invalid={invalidDueToProps ? 'true' : undefined}
-        aria-describedby={invalidDueToProps ? `${props.id}Hint` : undefined}
+        aria-describedby={describedBy.join(' ')}
         defaultValue={props.defaultValue}
         className={inputClassName()}
         disabled={props.disabled}
@@ -163,6 +168,7 @@ AbstractCustomField.propTypes = {
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
   step: PropTypes.number,
+  tooltip: PropTypes.string,
   type: PropTypes.oneOf([
     'date',
     'number',
@@ -201,6 +207,7 @@ AbstractCustomField.defaultProps = {
   readOnly: false,
   required: false,
   step: undefined,
+  tooltip: undefined,
   type: 'text',
   value: undefined,
 };

--- a/src/components/__internal__/abstract-custom-field/abstract-custom-field.test.jsx
+++ b/src/components/__internal__/abstract-custom-field/abstract-custom-field.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import user from '@testing-library/user-event';
 import AbstractCustomField from './abstract-custom-field.jsx';
 import Icon from '../../icon/icon.jsx';
 import calendarSvg from '../../../svgs/calendar.svg';
@@ -260,6 +261,23 @@ describe('AbstractCustomField', () => {
     it('can be set to `date`', () => {
       render(<AbstractCustomField {...sharedProps} type="date" />);
       expect(screen.getByLabelText('Test label')).toHaveAttribute('type', 'date');
+    });
+  });
+
+  describe('tooltip API', () => {
+    const tooltip = 'I am an input, short and stout.';
+
+    it('applies a description to the input when the help icon is hovered', () => {
+      render(<AbstractCustomField {...sharedProps} tooltip={tooltip} />);
+      user.hover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText('Test label')).toHaveDescription(tooltip);
+    });
+
+    it('removes the description to the input when the help icon is unhovered', () => {
+      render(<AbstractCustomField {...sharedProps} tooltip={tooltip} />);
+      user.hover(screen.getByRole('img', { name: 'More information' }));
+      user.unhover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText('Test label')).toHaveDescription('');
     });
   });
 });

--- a/src/components/autocompleter/__snapshots__/autocompleter.test.jsx.snap
+++ b/src/components/autocompleter/__snapshots__/autocompleter.test.jsx.snap
@@ -26,6 +26,7 @@ exports[`src/components/autocompleter/autocompleter has defaults 1`] = `
           <input
             aria-autocomplete="none"
             aria-controls="test-id-single-choice-listbox"
+            aria-describedby=""
             aria-expanded="false"
             aria-haspopup="listbox"
             autocomplete="off"

--- a/src/components/autocompleter/__snapshots__/autocompleter.test.jsx.snap
+++ b/src/components/autocompleter/__snapshots__/autocompleter.test.jsx.snap
@@ -26,7 +26,7 @@ exports[`src/components/autocompleter/autocompleter has defaults 1`] = `
           <input
             aria-autocomplete="none"
             aria-controls="test-id-single-choice-listbox"
-            aria-describedby=""
+            aria-describedby="test-id-tooltip test-idHint"
             aria-expanded="false"
             aria-haspopup="listbox"
             autocomplete="off"

--- a/src/components/autocompleter/autocompleter.jsx
+++ b/src/components/autocompleter/autocompleter.jsx
@@ -63,20 +63,21 @@ const Autocompleter = forwardRef(function Autocompleter(props, ref) {
 
   return (
     <Select
-      label={props.label}
-      id={props.id}
-      name={props.name}
       className={props.className}
-      listOptionRefs={listOptionRefs}
       displayValueEvaluator={props.displayValueEvaluator}
+      errorText={props.validationMessage}
+      id={props.id}
+      label={props.label}
+      listOptionRefs={listOptionRefs}
+      name={props.name}
       onChange={props.onChange}
       onInput={onInput}
-      required={props.required}
-      readOnly={props.readOnly}
       placeholder={props.placeholder}
-      errorText={props.validationMessage}
-      value={props.value}
+      readOnly={props.readOnly}
       ref={ref}
+      required={props.required}
+      tooltip={props.tooltip}
+      value={props.value}
     >
       {listOptionElements}
     </Select>
@@ -90,21 +91,22 @@ function displayName(modelInfo) {
 Autocompleter.propTypes = {
   /** `apiEndpoint` should be the route of the api's endpoint (excluding the base api), eg. `/workspaces`. */
   apiEndpoint: PropTypes.string,
+  className: PropTypes.string,
+  /** displayValueEvaluator is handled if the key following: `title`, `name`, `full_name`, `currency`; Otherwise, pass in something like `displayValueEvaluator: (model) -> { model.rate_card_name }` */
+  displayValueEvaluator: PropTypes.func,
   id: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
-  searchParam: PropTypes.string,
+  label: PropTypes.string,
   /** `value` and `models` shape is expected to be an object(s) with an `id` key */
   models: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string.required,
   })),
+  name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
-  /** displayValueEvaluator is handled if the key following: `title`, `name`, `full_name`, `currency`; Otherwise, pass in something like `displayValueEvaluator: (model) -> { model.rate_card_name }` */
-  displayValueEvaluator: PropTypes.func,
-  label: PropTypes.string,
-  required: PropTypes.bool,
-  readOnly: PropTypes.bool,
   placeholder: PropTypes.string,
-  className: PropTypes.string,
+  readOnly: PropTypes.bool,
+  required: PropTypes.bool,
+  searchParam: PropTypes.string,
+  tooltip: PropTypes.string,
   validationMessage: PropTypes.string,
   /** `value` and `models` shape is expected to be an object(s) with an `id` key */
   value: PropTypes.any, // eslint-disable-line react/forbid-prop-types
@@ -112,15 +114,16 @@ Autocompleter.propTypes = {
 
 Autocompleter.defaultProps = {
   apiEndpoint: undefined,
-  searchParam: 'matching',
-  models: [],
-  label: undefined,
-  required: false,
-  readOnly: false,
+  className: undefined,
   displayValueEvaluator: displayName,
+  label: undefined,
+  models: [],
   onChange: () => {},
   placeholder: undefined,
-  className: undefined,
+  readOnly: false,
+  required: false,
+  searchParam: 'matching',
+  tooltip: undefined,
   validationMessage: undefined,
   value: undefined,
 };

--- a/src/components/autocompleter/autocompleter.test.jsx
+++ b/src/components/autocompleter/autocompleter.test.jsx
@@ -226,4 +226,21 @@ describe('src/components/autocompleter/autocompleter', () => {
       expect(await screen.findByText('filter-stub')).toBeInTheDocument();
     });
   });
+
+  describe('tooltip API', () => {
+    const tooltip = 'I am an input, short and stout.';
+
+    it('applies a description to the input when the help icon is hovered', () => {
+      render(<Autocompleter {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription(tooltip);
+    });
+
+    it('removes the description to the input when the help icon is unhovered', () => {
+      render(<Autocompleter {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      userEvent.unhover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription('');
+    });
+  });
 });

--- a/src/components/checkbox/__snapshots__/checkbox.test.jsx.snap
+++ b/src/components/checkbox/__snapshots__/checkbox.test.jsx.snap
@@ -20,7 +20,7 @@ exports[`Checkbox has defaults 1`] = `
         class="control-container"
       >
         <input
-          aria-describedby="fartHint"
+          aria-describedby="fart-tooltip fartHint"
           class="input"
           id="fart"
           type="checkbox"

--- a/src/components/checkbox/checkbox.jsx
+++ b/src/components/checkbox/checkbox.jsx
@@ -61,8 +61,11 @@ const Checkbox = forwardRef(function Checkbox(props, forwardedRef) {
     if (props.readOnly && event.key === ' ') event.preventDefault();
   }
 
-  const describedBy = [`${props.id}Hint`];
-  if (props.tooltip) describedBy.push(`${props.id}-tooltip`);
+  const ids = {
+    input: props.id,
+    tooltip: `${props.id}-tooltip`,
+    validation: `${props.id}Hint`,
+  };
 
   return (
     <FormControl
@@ -75,7 +78,7 @@ const Checkbox = forwardRef(function Checkbox(props, forwardedRef) {
       tooltip={props.tooltip}
     >
       <input
-        aria-describedby={describedBy.join(' ')}
+        aria-describedby={`${ids.tooltip} ${ids.validation}`}
         className={props.className}
         defaultChecked={props.checked}
         id={props.id}

--- a/src/components/checkbox/checkbox.jsx
+++ b/src/components/checkbox/checkbox.jsx
@@ -61,6 +61,9 @@ const Checkbox = forwardRef(function Checkbox(props, forwardedRef) {
     if (props.readOnly && event.key === ' ') event.preventDefault();
   }
 
+  const describedBy = [`${props.id}Hint`];
+  if (props.tooltip) describedBy.push(`${props.id}-tooltip`);
+
   return (
     <FormControl
       className={props.cssContainer}
@@ -69,9 +72,10 @@ const Checkbox = forwardRef(function Checkbox(props, forwardedRef) {
       label={props.label}
       readOnly={props.readOnly}
       required={props.required}
+      tooltip={props.tooltip}
     >
       <input
-        aria-describedby={`${props.id}Hint`}
+        aria-describedby={describedBy.join(' ')}
         className={props.className}
         defaultChecked={props.checked}
         id={props.id}
@@ -109,6 +113,7 @@ Checkbox.propTypes = {
   onFocus: PropTypes.func,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
+  tooltip: PropTypes.string,
   validationMessage: PropTypes.string,
   value: PropTypes.string,
 };
@@ -123,6 +128,7 @@ Checkbox.defaultProps = {
   onFocus: () => {},
   readOnly: undefined,
   required: undefined,
+  tooltip: undefined,
   validationMessage: '',
   value: undefined,
 };

--- a/src/components/checkbox/checkbox.test.jsx
+++ b/src/components/checkbox/checkbox.test.jsx
@@ -203,6 +203,23 @@ describe('Checkbox', () => {
     });
   });
 
+  describe('tooltip API', () => {
+    const tooltip = 'I am an input, short and stout.';
+
+    it('applies a description to the input when the help icon is hovered', () => {
+      render(<Checkbox {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription(tooltip);
+    });
+
+    it('removes the description to the input when the help icon is unhovered', () => {
+      render(<Checkbox {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      userEvent.unhover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription('');
+    });
+  });
+
   describe('required api', () => {
     it('can be set', () => {
       render(<Checkbox {...requiredProps} required />);

--- a/src/components/custom-field-input-currency/custom-field-input-currency.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.jsx
@@ -125,6 +125,7 @@ const CustomFieldInputCurrency = forwardRef(function CustomFieldInputCurrency(pr
     placeholder: props.placeholder,
     readOnly: props.readOnly,
     required: props.required,
+    tooltip: props.tooltip,
   };
 
   const formattedNumber = formatValue(input, props.currencyCode);
@@ -169,6 +170,7 @@ CustomFieldInputCurrency.propTypes = {
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
+  tooltip: PropTypes.string,
   value: PropTypes.number,
 };
 
@@ -181,6 +183,7 @@ CustomFieldInputCurrency.defaultProps = {
   placeholder: undefined,
   readOnly: false,
   required: false,
+  tooltip: undefined,
   value: undefined,
 };
 

--- a/src/components/custom-field-input-currency/custom-field-input-currency.test.jsx
+++ b/src/components/custom-field-input-currency/custom-field-input-currency.test.jsx
@@ -231,4 +231,21 @@ describe('CustomFieldInputCurrency', () => {
       expect(ref.current.value).toBeUndefined();
     });
   });
+
+  describe('tooltip API', () => {
+    const tooltip = 'I am an input, short and stout.';
+
+    it('applies a description to the input when the help icon is hovered', () => {
+      render(<CustomFieldInputCurrency {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription(tooltip);
+    });
+
+    it('removes the description to the input when the help icon is unhovered', () => {
+      render(<CustomFieldInputCurrency {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      userEvent.unhover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription('');
+    });
+  });
 });

--- a/src/components/custom-field-input-date/__snapshots__/custom-field-input-date.test.jsx.snap
+++ b/src/components/custom-field-input-date/__snapshots__/custom-field-input-date.test.jsx.snap
@@ -24,7 +24,7 @@ exports[`src/components/custom-field-input-date/custom-field-input-date classNam
           class="control-container"
         >
           <input
-            aria-describedby="field-dateHint"
+            aria-describedby="field-dateHint field-date-tooltip"
             class="unique-input"
             id="field-date"
             name="field-name"
@@ -80,7 +80,7 @@ exports[`src/components/custom-field-input-date/custom-field-input-date has defa
           class="control-container"
         >
           <input
-            aria-describedby="field-dateHint"
+            aria-describedby="field-dateHint field-date-tooltip"
             class="input"
             id="field-date"
             name="field-name"

--- a/src/components/custom-field-input-date/custom-field-input-date.jsx
+++ b/src/components/custom-field-input-date/custom-field-input-date.jsx
@@ -25,6 +25,7 @@ CustomFieldInputDate.propTypes = {
   onChange: PropTypes.func,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
+  tooltip: PropTypes.string,
   value: PropTypes.string,
 };
 
@@ -37,6 +38,7 @@ CustomFieldInputDate.defaultProps = {
   placeholder: undefined,
   readOnly: false,
   required: false,
+  tooltip: undefined,
   value: undefined,
 };
 

--- a/src/components/custom-field-input-date/custom-field-input-date.test.jsx
+++ b/src/components/custom-field-input-date/custom-field-input-date.test.jsx
@@ -268,4 +268,21 @@ describe('src/components/custom-field-input-date/custom-field-input-date', () =>
       expect(inputRef.current.value).toBe('2016-07-18');
     });
   });
+
+  describe('tooltip API', () => {
+    const tooltip = 'I am an input, short and stout.';
+
+    it('applies a description to the input when the help icon is hovered', () => {
+      render(<CustomFieldInputDate {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription(tooltip);
+    });
+
+    it('removes the description to the input when the help icon is unhovered', () => {
+      render(<CustomFieldInputDate {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      userEvent.unhover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription('');
+    });
+  });
 });

--- a/src/components/custom-field-input-multiple-choice/__snapshots__/custom-field-input-multiple-choice.test.jsx.snap
+++ b/src/components/custom-field-input-multiple-choice/__snapshots__/custom-field-input-multiple-choice.test.jsx.snap
@@ -35,7 +35,7 @@ exports[`<CustomFieldInputMultipleChoice> has defaults 1`] = `
               <input
                 aria-autocomplete="list"
                 aria-controls="test-id-listbox"
-                aria-describedby="test-id-autocompleteHint test-id-empty"
+                aria-describedby="test-id-autocompleteHint test-id-empty test-id-autocomplete-tooltip"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="test-id-label"

--- a/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.jsx
+++ b/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.jsx
@@ -57,6 +57,7 @@ const CustomFieldInputMultipleChoice = forwardRef(function CustomFieldInputMulti
     label: `${props.id}-label`,
     listbox: `${props.id}-listbox`,
     textbox: `${props.id}-autocomplete`,
+    tooltip: `${props.id}-autocomplete-tooltip`,
   };
   const mounted = useMounted();
   const wrapperRef = useRef(null);
@@ -219,10 +220,11 @@ const CustomFieldInputMultipleChoice = forwardRef(function CustomFieldInputMulti
     <div ref={wrapperRef} className={styles['component-root']}>
       <FormControl
         error={validationMessage}
+        id={ids.textbox}
         label={props.label}
         labelId={ids.label}
-        id={ids.textbox}
         onKeyDown={onKeyDown}
+        tooltip={props.tooltip}
         readOnly={props.readOnly}
       >
         <div
@@ -252,7 +254,7 @@ const CustomFieldInputMultipleChoice = forwardRef(function CustomFieldInputMulti
             <input
               aria-autocomplete="list"
               aria-controls={ids.listbox}
-              aria-describedby={`${ids.errorMessage} ${ids.emptyMessage}`}
+              aria-describedby={`${ids.errorMessage} ${ids.emptyMessage} ${ids.tooltip}`}
               aria-expanded={expanded}
               aria-haspopup="listbox"
               aria-labelledby={ids.label}
@@ -315,6 +317,7 @@ CustomFieldInputMultipleChoice.propTypes = {
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
+  tooltip: PropTypes.string,
   value: PropTypes.arrayOf(PropTypes.string),
 };
 
@@ -325,6 +328,7 @@ CustomFieldInputMultipleChoice.defaultProps = {
   placeholder: undefined,
   readOnly: false,
   required: false,
+  tooltip: undefined,
   value: [],
 };
 

--- a/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.test.jsx
+++ b/src/components/custom-field-input-multiple-choice/custom-field-input-multiple-choice.test.jsx
@@ -325,6 +325,23 @@ describe('<CustomFieldInputMultipleChoice>', () => {
     });
   });
 
+  describe('tooltip API', () => {
+    const tooltip = 'I am an input, short and stout.';
+
+    it('applies a description to the input when the help icon is hovered', () => {
+      render(<CustomFieldInputMultipleChoice {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByRole('combobox', { name: requiredProps.label })).toHaveDescription(tooltip);
+    });
+
+    it('removes the description to the input when the help icon is unhovered', () => {
+      render(<CustomFieldInputMultipleChoice {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      userEvent.unhover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByRole('combobox', { name: requiredProps.label })).toHaveDescription('');
+    });
+  });
+
   describe('value API', () => {
     it('generates tags', async () => {
       render((<CustomFieldInputMultipleChoice

--- a/src/components/custom-field-input-number/__snapshots__/custom-field-input-number.test.jsx.snap
+++ b/src/components/custom-field-input-number/__snapshots__/custom-field-input-number.test.jsx.snap
@@ -20,7 +20,7 @@ exports[`CustomFieldInputNumber has defaults 1`] = `
         class="control-container"
       >
         <input
-          aria-describedby="test-inputHint"
+          aria-describedby="test-input-tooltip test-inputHint"
           class="custom-field-input-text"
           id="test-input"
           max="2147483648"

--- a/src/components/custom-field-input-number/custom-field-input-number.jsx
+++ b/src/components/custom-field-input-number/custom-field-input-number.jsx
@@ -31,8 +31,6 @@ const CustomFieldInputNumber = forwardRef(function CustomFieldInputNumber(props,
   return (
     <Number
       className={props.className}
-      value={props.value}
-      validationMessage={props.errorText}
       id={props.id}
       label={props.label}
       max={apiLimits.max}
@@ -45,7 +43,10 @@ const CustomFieldInputNumber = forwardRef(function CustomFieldInputNumber(props,
       ref={inputRef}
       required={props.required}
       step={props.step}
+      tooltip={props.tooltip}
       type="number"
+      validationMessage={props.errorText}
+      value={props.value}
     />
   );
 });
@@ -68,6 +69,7 @@ CustomFieldInputNumber.propTypes = {
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
   step: PropTypes.number,
+  tooltip: PropTypes.string,
   value: PropTypes.number,
 };
 
@@ -82,6 +84,7 @@ CustomFieldInputNumber.defaultProps = {
   readOnly: false,
   required: false,
   step: 1,
+  tooltip: undefined,
   value: undefined,
 };
 

--- a/src/components/custom-field-input-number/custom-field-input-number.test.jsx
+++ b/src/components/custom-field-input-number/custom-field-input-number.test.jsx
@@ -228,4 +228,21 @@ describe('CustomFieldInputNumber', () => {
       expect(inputRef.current.value).toBe(1234);
     });
   });
+
+  describe('tooltip API', () => {
+    const tooltip = 'I am an input, short and stout.';
+
+    it('applies a description to the input when the help icon is hovered', () => {
+      render(<CustomFieldInputNumber {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription(tooltip);
+    });
+
+    it('removes the description to the input when the help icon is unhovered', () => {
+      render(<CustomFieldInputNumber {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      userEvent.unhover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription('');
+    });
+  });
 });

--- a/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
+++ b/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
@@ -26,6 +26,7 @@ exports[`src/components/custom-field-input-single-choice/custom-field-input-sing
           <input
             aria-autocomplete="none"
             aria-controls="test-id-single-choice-listbox"
+            aria-describedby=""
             aria-expanded="false"
             aria-haspopup="listbox"
             autocomplete="off"

--- a/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
+++ b/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
@@ -26,7 +26,7 @@ exports[`src/components/custom-field-input-single-choice/custom-field-input-sing
           <input
             aria-autocomplete="none"
             aria-controls="test-id-single-choice-listbox"
-            aria-describedby=""
+            aria-describedby="test-id-tooltip test-idHint"
             aria-expanded="false"
             aria-haspopup="listbox"
             autocomplete="off"

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -103,6 +103,7 @@ const CustomFieldInputSingleChoice = forwardRef(function CustomFieldInputSingleC
         placeholder={props.placeholder}
         readOnly={props.readOnly}
         required={props.required}
+        tooltip={props.tooltip}
         value={value[0] !== -1 ? choices.find(choice => choice.id === value[0]) : undefined}
       >
         {choices.length === 0
@@ -115,28 +116,30 @@ const CustomFieldInputSingleChoice = forwardRef(function CustomFieldInputSingleC
 });
 
 CustomFieldInputSingleChoice.propTypes = {
-  id: PropTypes.string.isRequired,
   className: PropTypes.string,
   /** Needs to be the Custom Field ID from the database for self-loading of choices */
   customFieldID: PropTypes.string.isRequired,
+  errorText: PropTypes.string,
+  id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
+  tooltip: PropTypes.string,
   value: PropTypes.arrayOf(PropTypes.string),
-  errorText: PropTypes.string,
 };
 
 CustomFieldInputSingleChoice.defaultProps = {
   className: undefined,
+  errorText: undefined,
   onChange: () => {},
   placeholder: undefined,
   readOnly: false,
   required: false,
+  tooltip: undefined,
   value: defaultValue,
-  errorText: undefined,
 };
 
 export default CustomFieldInputSingleChoice;

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
@@ -13,6 +13,7 @@ import {
   selectChoice,
   waitForChoices,
 } from './test-queries.js';
+import user from '@testing-library/user-event';
 
 describe('src/components/custom-field-input-single-choice/custom-field-input-single-choice', () => {
   beforeEach(() => {
@@ -202,6 +203,23 @@ describe('src/components/custom-field-input-single-choice/custom-field-input-sin
 
       await waitForChoices('Test label');
       selectChoice('Test label', 'Foo');
+    });
+  });
+
+  describe('tooltip API', () => {
+    const tooltip = 'I am an input, short and stout.';
+
+    it('applies a description to the input when the help icon is hovered', () => {
+      render(<CustomFieldInputSingleChoice {...requiredProps} tooltip={tooltip} />);
+      user.hover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription(tooltip);
+    });
+
+    it('removes the description to the input when the help icon is unhovered', () => {
+      render(<CustomFieldInputSingleChoice {...requiredProps} tooltip={tooltip} />);
+      user.hover(screen.getByRole('img', { name: 'More information' }));
+      user.unhover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription('');
     });
   });
 });

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.test.jsx
@@ -4,6 +4,7 @@ import {
   render,
   screen,
 } from '@testing-library/react';
+import user from '@testing-library/user-event';
 import jestServer from '../../mocks/jest-server.js';
 import CustomFieldInputSingleChoice from './custom-field-input-single-choice.jsx';
 import mockHandlers from './mock-handlers.js';
@@ -13,7 +14,6 @@ import {
   selectChoice,
   waitForChoices,
 } from './test-queries.js';
-import user from '@testing-library/user-event';
 
 describe('src/components/custom-field-input-single-choice/custom-field-input-single-choice', () => {
   beforeEach(() => {

--- a/src/components/custom-field-input-text/custom-field-input-text.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.jsx
@@ -18,6 +18,7 @@ const CustomFieldInputText = forwardRef(function CustomFieldInputText(props, ref
       readOnly={props.readOnly}
       ref={ref}
       required={props.required}
+      tooltip={props.tooltip}
       type="text"
       validationMessage={props.errorText}
       value={props.value}
@@ -40,6 +41,7 @@ CustomFieldInputText.propTypes = {
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
+  tooltip: PropTypes.string,
   value: PropTypes.string,
 };
 
@@ -53,6 +55,7 @@ CustomFieldInputText.defaultProps = {
   placeholder: undefined,
   readOnly: false,
   required: false,
+  tooltip: undefined,
   value: undefined,
 };
 

--- a/src/components/custom-field-input-text/custom-field-input-text.test.jsx
+++ b/src/components/custom-field-input-text/custom-field-input-text.test.jsx
@@ -88,4 +88,21 @@ describe('CustomFieldInputText', () => {
       expect(screen.getByLabelText('Test label')).toHaveDescription('Constraints not satisfied');
     });
   });
+
+  describe('tooltip API', () => {
+    const tooltip = 'I am an input, short and stout.';
+
+    it('applies a description to the input when the help icon is hovered', () => {
+      render(<CustomFieldInputText {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription(tooltip);
+    });
+
+    it('removes the description to the input when the help icon is unhovered', () => {
+      render(<CustomFieldInputText {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      userEvent.unhover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription('');
+    });
+  });
 });

--- a/src/components/date/__snapshots__/date.test.jsx.snap
+++ b/src/components/date/__snapshots__/date.test.jsx.snap
@@ -24,7 +24,7 @@ exports[`src/components/date/date.test.jsx classNames API sets various class nam
           class="control-container"
         >
           <input
-            aria-describedby="test-idHint"
+            aria-describedby="test-idHint test-id-tooltip"
             class="unique-input"
             id="test-id"
             name="test_name"
@@ -80,7 +80,7 @@ exports[`src/components/date/date.test.jsx classNames API sets various class nam
           class="control-container"
         >
           <input
-            aria-describedby="test-idHint"
+            aria-describedby="test-idHint test-id-tooltip"
             class="unique-input"
             id="test-id"
             name="test_name"
@@ -672,7 +672,7 @@ exports[`src/components/date/date.test.jsx has defaults 1`] = `
           class="control-container"
         >
           <input
-            aria-describedby="test-idHint"
+            aria-describedby="test-idHint test-id-tooltip"
             class="input"
             id="test-id"
             name="test_name"

--- a/src/components/date/date.jsx
+++ b/src/components/date/date.jsx
@@ -85,6 +85,7 @@ const Date = forwardRef(function Date(props, forwardedRef) {
   const ids = {
     input: props.id,
     label: `${props.id}-label`,
+    tooltip: `${props.id}-tooltip`,
     validationMessage: `${props.id}Hint`,
   };
 
@@ -190,9 +191,10 @@ const Date = forwardRef(function Date(props, forwardedRef) {
         label={props.label}
         readOnly={props.readOnly}
         required={props.required}
+        tooltip={props.tooltip}
       >
         <input
-          aria-describedby={ids.validationMessage}
+          aria-describedby={`${ids.validationMessage} ${ids.tooltip}`}
           className={classNames.input}
           defaultValue={editing ? toFullDateFormat(value) : toDateStringFormat(value)}
           id={ids.input}
@@ -244,6 +246,7 @@ Date.propTypes = {
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
+  tooltip: PropTypes.string,
   validationMessage: PropTypes.string,
   /** A date in full-date format (i.e. yyyy-mm-dd) */
   value: PropTypes.string,
@@ -257,6 +260,7 @@ Date.defaultProps = {
   placeholder: undefined,
   readOnly: false,
   required: false,
+  tooltip: undefined,
   validationMessage: '',
   value: undefined,
 };

--- a/src/components/date/date.test.jsx
+++ b/src/components/date/date.test.jsx
@@ -331,6 +331,23 @@ describe('src/components/date/date.test.jsx', () => {
     });
   });
 
+  describe('tooltip API', () => {
+    const tooltip = 'I am an input, short and stout.';
+
+    it('applies a description to the input when the help icon is hovered', () => {
+      render(<Date {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription(tooltip);
+    });
+
+    it('removes the description to the input when the help icon is unhovered', () => {
+      render(<Date {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      userEvent.unhover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription('');
+    });
+  });
+
   describe('validationMessage API', () => {
     it('is a string', () => {
       const { rerender } = render(<Date {...requiredProps} validationMessage="This is a provided error." />);

--- a/src/components/multi-autocompleter/__snapshots__/multi-autocompleter.test.jsx.snap
+++ b/src/components/multi-autocompleter/__snapshots__/multi-autocompleter.test.jsx.snap
@@ -36,7 +36,7 @@ exports[`<MultiAutocompleter> className API uses class name provided 1`] = `
               <input
                 aria-autocomplete="list"
                 aria-controls="test-id-listbox"
-                aria-describedby="test-id-empty"
+                aria-describedby="test-id-empty test-id-autocomplete-tooltip"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 autocomplete="off"
@@ -108,7 +108,7 @@ exports[`<MultiAutocompleter> has defaults 1`] = `
               <input
                 aria-autocomplete="list"
                 aria-controls="test-id-listbox"
-                aria-describedby="test-id-empty"
+                aria-describedby="test-id-empty test-id-autocomplete-tooltip"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 autocomplete="off"

--- a/src/components/multi-autocompleter/multi-autocompleter.jsx
+++ b/src/components/multi-autocompleter/multi-autocompleter.jsx
@@ -56,14 +56,15 @@ const MultiAutocompleter = forwardRef(function MultiAutocompleter(props, ref) {
       name={props.name}
       onChange={onMultiSelectChange}
       onInput={onMultiSelectInput}
-      options={options}
       optionIDGetter={props.optionIDGetter}
       optionLabelGetter={props.optionLabelGetter}
+      options={options}
       placeholder={props.placeholder}
       readOnly={props.readOnly}
       ref={ref}
       required={props.required}
       showLoader={loading}
+      tooltip={props.tooltip}
       validationMessage={validationMessage}
       value={props.value}
     />
@@ -84,6 +85,7 @@ MultiAutocompleter.propTypes = {
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
   searchParam: PropTypes.string,
+  tooltip: PropTypes.string,
   validationMessage: PropTypes.string,
   /** value is an array of objects matching the shape of options */
   value: PropTypes.arrayOf(PropTypes.object),
@@ -98,6 +100,7 @@ MultiAutocompleter.defaultProps = {
   readOnly: false,
   required: false,
   searchParam: 'matching',
+  tooltip: undefined,
   validationMessage: undefined,
   value: [],
 };

--- a/src/components/multi-autocompleter/multi-autocompleter.test.jsx
+++ b/src/components/multi-autocompleter/multi-autocompleter.test.jsx
@@ -253,4 +253,21 @@ describe('<MultiAutocompleter>', () => {
       expect(await findSelectedOption('test label', 'Bar')).toBeInTheDocument();
     });
   });
+
+  describe('tooltip API', () => {
+    const tooltip = 'I am an input, short and stout.';
+
+    it('applies a description to the input when the help icon is hovered', () => {
+      render(<MultiAutocompleter {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByRole('combobox', { name: requiredProps.label })).toHaveDescription(tooltip);
+    });
+
+    it('removes the description to the input when the help icon is unhovered', () => {
+      render(<MultiAutocompleter {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      userEvent.unhover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByRole('combobox', { name: requiredProps.label })).toHaveDescription('');
+    });
+  });
 });

--- a/src/components/multi-select/__snapshots__/multi-select.test.jsx.snap
+++ b/src/components/multi-select/__snapshots__/multi-select.test.jsx.snap
@@ -36,7 +36,7 @@ exports[`<MultiSelect> classNames API uses class name overrides provided 1`] = `
               <input
                 aria-autocomplete="list"
                 aria-controls="test-id-listbox"
-                aria-describedby="test-id-empty"
+                aria-describedby="test-id-empty test-id-autocomplete-tooltip"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 autocomplete="off"
@@ -108,7 +108,7 @@ exports[`<MultiSelect> has defaults 1`] = `
               <input
                 aria-autocomplete="list"
                 aria-controls="test-id-listbox"
-                aria-describedby="test-id-empty"
+                aria-describedby="test-id-empty test-id-autocomplete-tooltip"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 autocomplete="off"

--- a/src/components/multi-select/multi-select.jsx
+++ b/src/components/multi-select/multi-select.jsx
@@ -52,6 +52,7 @@ const MultiSelect = forwardRef(function MultiSelect(props, ref) {
     label: `${props.id}-label`,
     listbox: `${props.id}-listbox`,
     textbox: `${props.id}-autocomplete`,
+    tooltip: `${props.id}-autocomplete-tooltip`,
   };
 
   const classNames = {
@@ -217,12 +218,13 @@ const MultiSelect = forwardRef(function MultiSelect(props, ref) {
   return (
     <div className={classNames.container} id={props.id} ref={wrapperRef}>
       <FormControl
+        error={validationMessage}
+        id={ids.textbox}
         label={props.label}
         labelId={ids.label}
-        id={ids.textbox}
-        error={validationMessage}
         onKeyDown={onKeyDown}
         required={props.required}
+        tooltip={props.tooltip}
       >
         <div role="presentation" className={classNames.formControlChildrenContainer} onClick={onClick}>
           <TagList
@@ -231,7 +233,7 @@ const MultiSelect = forwardRef(function MultiSelect(props, ref) {
             refs={valueRefs}
           >
             {value.length !== 0 &&
-              props.tagChildren ?
+            props.tagChildren ?
               props.tagChildren(value, valueRefs, onOptionRemove) :
               value.map((val, index) => (
                 <Tag
@@ -249,7 +251,7 @@ const MultiSelect = forwardRef(function MultiSelect(props, ref) {
             <input
               aria-autocomplete="list"
               aria-controls={ids.listbox}
-              aria-describedby={`${ids.emptyMessage}`}
+              aria-describedby={`${ids.emptyMessage} ${ids.tooltip}`}
               aria-expanded={expanded}
               aria-haspopup="listbox"
               autoComplete="off"
@@ -316,6 +318,7 @@ MultiSelect.propTypes = {
   required: PropTypes.bool,
   showLoader: PropTypes.bool, // eslint-disable-line react/no-unused-prop-types
   tagChildren: PropTypes.func,
+  tooltip: PropTypes.string,
   validationMessage: PropTypes.string,
   /** value is expected to be an array of objects that matches the "option" structure */
   value: PropTypes.arrayOf(PropTypes.object),
@@ -334,6 +337,7 @@ MultiSelect.defaultProps = {
   required: false,
   showLoader: false,
   tagChildren: undefined,
+  tooltip: undefined,
   value: [],
   validationMessage: undefined,
 };

--- a/src/components/multi-select/multi-select.test.jsx
+++ b/src/components/multi-select/multi-select.test.jsx
@@ -524,4 +524,21 @@ describe('<MultiSelect>', () => {
       expect(ref.current.dirty).toBeTruthy();
     });
   });
+
+  describe('tooltip API', () => {
+    const tooltip = 'I am an input, short and stout.';
+
+    it('applies a description to the input when the help icon is hovered', () => {
+      render(<MultiSelect {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByRole('combobox', { name: requiredProps.label })).toHaveDescription(tooltip);
+    });
+
+    it('removes the description to the input when the help icon is unhovered', () => {
+      render(<MultiSelect {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      userEvent.unhover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByRole('combobox', { name: requiredProps.label })).toHaveDescription('');
+    });
+  });
 });

--- a/src/components/number/__snapshots__/number.test.jsx.snap
+++ b/src/components/number/__snapshots__/number.test.jsx.snap
@@ -20,7 +20,7 @@ exports[`Number has defaults 1`] = `
         class="control-container"
       >
         <input
-          aria-describedby="test-componentHint"
+          aria-describedby="test-component-tooltip test-componentHint"
           class="input"
           id="test-component"
           max="2147483648"

--- a/src/components/number/number.jsx
+++ b/src/components/number/number.jsx
@@ -60,6 +60,9 @@ const Number = React.forwardRef((props, ref) => {
     },
   }));
 
+  const describedBy = [`${props.id}Hint`];
+  if (props.tooltip) describedBy.push(`${props.id}-tooltip`);
+
   return (
     <FormControl
       error={validationMessage}
@@ -67,9 +70,10 @@ const Number = React.forwardRef((props, ref) => {
       label={props.label}
       readOnly={props.readOnly}
       required={props.required}
+      tooltip={props.tooltip}
     >
       <input
-        aria-describedby={`${props.id}Hint`}
+        aria-describedby={describedBy.join(' ')}
         className={getClassName(props.className, validationMessage)}
         defaultValue={props.value}
         id={props.id}
@@ -112,6 +116,7 @@ Number.propTypes = {
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
   step: PropTypes.number,
+  tooltip: PropTypes.string,
   validationMessage: PropTypes.string,
   value: PropTypes.number,
 };
@@ -125,6 +130,7 @@ Number.defaultProps = {
   readOnly: false,
   required: false,
   step: 1,
+  tooltip: undefined,
   validationMessage: '',
   value: undefined,
 };

--- a/src/components/number/number.jsx
+++ b/src/components/number/number.jsx
@@ -60,23 +60,26 @@ const Number = React.forwardRef((props, ref) => {
     },
   }));
 
-  const describedBy = [`${props.id}Hint`];
-  if (props.tooltip) describedBy.push(`${props.id}-tooltip`);
+  const ids = {
+    input: props.id,
+    tooltip: `${props.id}-tooltip`,
+    validation: `${props.id}Hint`,
+  };
 
   return (
     <FormControl
       error={validationMessage}
-      id={props.id}
+      id={ids.input}
       label={props.label}
       readOnly={props.readOnly}
       required={props.required}
       tooltip={props.tooltip}
     >
       <input
-        aria-describedby={describedBy.join(' ')}
+        aria-describedby={`${ids.tooltip} ${ids.validation}`}
         className={getClassName(props.className, validationMessage)}
         defaultValue={props.value}
-        id={props.id}
+        id={ids.input}
         max={apiLimits.max}
         min={apiLimits.min}
         name={props.name}

--- a/src/components/number/number.test.jsx
+++ b/src/components/number/number.test.jsx
@@ -167,6 +167,23 @@ describe('Number', () => {
     });
   });
 
+  describe('tooltip API', () => {
+    const tooltip = 'I am an input, short and stout.';
+
+    it('applies a description to the input when the help icon is hovered', () => {
+      render(<Number {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription(tooltip);
+    });
+
+    it('removes the description to the input when the help icon is unhovered', () => {
+      render(<Number {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      userEvent.unhover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription('');
+    });
+  });
+
   describe('value API', () => {
     it('sets the value', () => {
       render(<Number {...requiredProps} value={12} />);

--- a/src/components/percentage/__snapshots__/percentage.test.jsx.snap
+++ b/src/components/percentage/__snapshots__/percentage.test.jsx.snap
@@ -21,7 +21,7 @@ exports[`Percentage has defaults 1`] = `
         class="control-container"
       >
         <input
-          aria-describedby="fooHint"
+          aria-describedby="fooHint foo-tooltip"
           class="input"
           id="foo"
           max="100"

--- a/src/components/percentage/percentage.jsx
+++ b/src/components/percentage/percentage.jsx
@@ -26,6 +26,7 @@ const Percentage = forwardRef(function Percentage(props, forwardedRef) {
   };
   const ids = {
     validationMessage: `${props.id}Hint`,
+    tooltip: `${props.id}-tooltip`,
   };
 
   function onBlur() {
@@ -60,15 +61,15 @@ const Percentage = forwardRef(function Percentage(props, forwardedRef) {
       label={props.label}
       readOnly={props.readOnly}
       required={props.required}
+      tooltip={props.tooltip}
     >
       <input
-        aria-describedby={ids.validationMessage}
+        aria-describedby={`${ids.validationMessage} ${ids.tooltip}`}
         className={getClassName(classNames.input, validationMessage)}
         defaultValue={props.value}
         id={props.id}
         max={100}
         min={0}
-        step={0.01}
         name={props.name}
         onBlur={onBlur}
         onChange={onChange}
@@ -76,6 +77,7 @@ const Percentage = forwardRef(function Percentage(props, forwardedRef) {
         readOnly={props.readOnly}
         ref={inputRef}
         required={props.required}
+        step={0.01}
         type="number"
       />
       <FormControlIcons validationMessage={validationMessage} className={styles['icons-container']}>
@@ -95,6 +97,7 @@ Percentage.propTypes = {
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
+  tooltip: PropTypes.string,
   validationMessage: PropTypes.string,
   value: (props, propName, componentName) => {
     const propValue = props[propName];
@@ -125,6 +128,7 @@ Percentage.defaultProps = {
   placeholder: undefined,
   readOnly: undefined,
   required: undefined,
+  tooltip: undefined,
   validationMessage: '',
   value: undefined,
 };

--- a/src/components/percentage/percentage.test.jsx
+++ b/src/components/percentage/percentage.test.jsx
@@ -165,6 +165,23 @@ describe('Percentage', () => {
     });
   });
 
+  describe('tooltip API', () => {
+    const tooltip = 'I am an input, short and stout.';
+
+    it('applies a description to the input when the help icon is hovered', () => {
+      render(<Percentage {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription(tooltip);
+    });
+
+    it('removes the description to the input when the help icon is unhovered', () => {
+      render(<Percentage {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      userEvent.unhover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText(requiredProps.label)).toHaveDescription('');
+    });
+  });
+
   describe('validationMessage API', () => {
     it('can be set', () => {
       render(<Percentage {...requiredProps} validationMessage="unique error" />);

--- a/src/components/select/__snapshots__/select.test.jsx.snap
+++ b/src/components/select/__snapshots__/select.test.jsx.snap
@@ -26,7 +26,7 @@ exports[`src/components/select/select has defaults 1`] = `
           <input
             aria-autocomplete="none"
             aria-controls="test-id-single-choice-listbox"
-            aria-describedby=""
+            aria-describedby="test-id-tooltip test-idHint"
             aria-expanded="false"
             aria-haspopup="listbox"
             autocomplete="off"

--- a/src/components/select/__snapshots__/select.test.jsx.snap
+++ b/src/components/select/__snapshots__/select.test.jsx.snap
@@ -26,6 +26,7 @@ exports[`src/components/select/select has defaults 1`] = `
           <input
             aria-autocomplete="none"
             aria-controls="test-id-single-choice-listbox"
+            aria-describedby=""
             aria-expanded="false"
             aria-haspopup="listbox"
             autocomplete="off"

--- a/src/components/select/select.jsx
+++ b/src/components/select/select.jsx
@@ -172,23 +172,6 @@ const Select = forwardRef(function Select(props, ref) {
   return (
     <div ref={wrapperRef} className={props.className}>
       <AbstractCustomField
-        icon={caretIcon}
-        clear={clearIcon()}
-        id={props.id}
-        label={props.label}
-        name={props.name}
-        onChange={onSearchChange}
-        onClick={onClick}
-        onKeyDown={onKeyDown}
-        onInput={props.onInput}
-        placeholder={props.placeholder}
-        readOnly={props.readOnly}
-        inputRef={inputRef}
-        required={props.required}
-        errorText={validationMessage}
-        value={searchValue || defaultValue}
-        onBlur={handleBlur}
-        inputRole={'combobox'}
         ariaProps={{
           autocomplete: 'none',
           controls: `${props.id}-single-choice-listbox`,
@@ -196,6 +179,24 @@ const Select = forwardRef(function Select(props, ref) {
           haspopup: 'listbox',
         }}
         autoComplete="off"
+        clear={clearIcon()}
+        errorText={validationMessage}
+        icon={caretIcon}
+        id={props.id}
+        inputRef={inputRef}
+        inputRole="combobox"
+        label={props.label}
+        name={props.name}
+        onBlur={handleBlur}
+        onChange={onSearchChange}
+        onClick={onClick}
+        onInput={props.onInput}
+        onKeyDown={onKeyDown}
+        placeholder={props.placeholder}
+        readOnly={props.readOnly}
+        required={props.required}
+        tooltip={props.tooltip}
+        value={searchValue || defaultValue}
       />
       { showOptions && (
         (!props.children || props.children.length === 0) ? (<NoOptions className={styles['no-options']} />) : (
@@ -225,7 +226,6 @@ const ListOptionRefType = PropTypes.shape({
 });
 
 Select.propTypes = {
-  id: PropTypes.string.isRequired,
   children: PropTypes.node,
   className: PropTypes.string,
   /** Function is passed `value`, default returns value without modification, should always return a `string`. You *should* set this if your `value` is not of type `string`. Pass in `false` to prevent filtering. */
@@ -234,6 +234,7 @@ Select.propTypes = {
     PropTypes.bool,
   ]),
   errorText: PropTypes.string,
+  id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   listOptionRefs: PropTypes.arrayOf(ListOptionRefType).isRequired,
   name: PropTypes.string.isRequired,
@@ -242,6 +243,7 @@ Select.propTypes = {
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
+  tooltip: PropTypes.string,
   value: PropTypes.any, // eslint-disable-line react/forbid-prop-types
 };
 
@@ -255,6 +257,7 @@ Select.defaultProps = {
   placeholder: undefined,
   readOnly: false,
   required: false,
+  tooltip: undefined,
   value: undefined,
 };
 

--- a/src/components/select/select.test.jsx
+++ b/src/components/select/select.test.jsx
@@ -418,6 +418,23 @@ describe('src/components/select/select', () => {
     });
   });
 
+  describe('tooltip API', () => {
+    const tooltip = 'I am an input, short and stout.';
+
+    it('applies a description to the input when the help icon is hovered', () => {
+      render(<Select {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByRole('combobox', { name: requiredProps.label })).toHaveDescription(tooltip);
+    });
+
+    it('removes the description to the input when the help icon is unhovered', () => {
+      render(<Select {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      userEvent.unhover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByRole('combobox', { name: requiredProps.label })).toHaveDescription('');
+    });
+  });
+
   describe('dropdown close behavior', () => {
     beforeEach(() => {
       render((

--- a/src/components/textarea/__snapshots__/textarea.test.jsx.snap
+++ b/src/components/textarea/__snapshots__/textarea.test.jsx.snap
@@ -20,7 +20,7 @@ exports[`Textarea has defaults 1`] = `
         class="control-container"
       >
         <textarea
-          aria-describedby="fooHint"
+          aria-describedby="foo-tooltip fooHint"
           class="textarea"
           id="foo"
         />

--- a/src/components/textarea/textarea.jsx
+++ b/src/components/textarea/textarea.jsx
@@ -28,6 +28,7 @@ const Textarea = forwardRef(function Textarea({
   placeholder,
   readOnly,
   required,
+  tooltip,
   validationMessage,
   value,
 }, forwardedRef) {
@@ -64,6 +65,9 @@ const Textarea = forwardRef(function Textarea({
     },
   }));
 
+  const describedBy = [`${id}Hint`];
+  if (tooltip) describedBy.push(`${id}-tooltip`);
+
   return (
     <FormControl
       className={cssContainer}
@@ -72,9 +76,10 @@ const Textarea = forwardRef(function Textarea({
       label={label}
       readOnly={readOnly}
       required={required}
+      tooltip={tooltip}
     >
       <textarea
-        aria-describedby={`${id}Hint`}
+        aria-describedby={describedBy.join(' ')}
         className={getClassName(className, validationMessageValue)}
         defaultValue={value}
         id={id}
@@ -108,6 +113,7 @@ Textarea.propTypes = {
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
+  tooltip: PropTypes.string,
   validationMessage: PropTypes.string,
   value: PropTypes.string,
 };
@@ -121,6 +127,7 @@ Textarea.defaultProps = {
   placeholder: undefined,
   readOnly: undefined,
   required: undefined,
+  tooltip: undefined,
   validationMessage: '',
   value: undefined,
 };

--- a/src/components/textarea/textarea.jsx
+++ b/src/components/textarea/textarea.jsx
@@ -65,24 +65,27 @@ const Textarea = forwardRef(function Textarea({
     },
   }));
 
-  const describedBy = [`${id}Hint`];
-  if (tooltip) describedBy.push(`${id}-tooltip`);
+  const ids = {
+    input: id,
+    tooltip: `${id}-tooltip`,
+    validation: `${id}Hint`,
+  };
 
   return (
     <FormControl
       className={cssContainer}
       error={validationMessageValue}
-      id={id}
+      id={ids.input}
       label={label}
       readOnly={readOnly}
       required={required}
       tooltip={tooltip}
     >
       <textarea
-        aria-describedby={describedBy.join(' ')}
+        aria-describedby={`${ids.tooltip} ${ids.validation}`}
         className={getClassName(className, validationMessageValue)}
         defaultValue={value}
-        id={id}
+        id={ids.input}
         name={name}
         onBlur={blurHandler}
         onChange={changeHandler}

--- a/src/components/textarea/textarea.test.jsx
+++ b/src/components/textarea/textarea.test.jsx
@@ -213,4 +213,21 @@ describe('Textarea', () => {
       expect(ref.current.value).toBe('!');
     });
   });
+
+  describe('tooltip API', () => {
+    const tooltip = 'I am an input, short and stout.';
+
+    it('applies a description to the input when the help icon is hovered', () => {
+      render(<Textarea {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText('the label')).toHaveDescription(tooltip);
+    });
+
+    it('removes the description to the input when the help icon is unhovered', () => {
+      render(<Textarea {...requiredProps} tooltip={tooltip} />);
+      userEvent.hover(screen.getByRole('img', { name: 'More information' }));
+      userEvent.unhover(screen.getByRole('img', { name: 'More information' }));
+      expect(screen.getByLabelText('the label')).toHaveDescription('');
+    });
+  });
 });


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178529112

```
  - feat(help-icon): Initial creation HelpIcon component
  - Added help text icon as optional prop the following components:
    - abstract-custom-field
    - autocompleter
    - checkbox
    - custom-field-input-currency
    - custom-field-input-date
    - custom-field-input-multiple-choice
    - custom-field-input-number
    - custom-field-input-single-choice
    - custom-field-input-text
    - date
    - input
    - multi-autocompleter
    - multi-select
    - number
    - percentage
    - select
    - textarea
   ```

The listed components all now have a `tooltip` prop which makes a `HelpIcon` appear like is on the mds input component.

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-help-on-form-controls-broadly-178529112/
- [x] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
