### PR TITLE
fix(tooltip): resolve `overflow: hidden` issue

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,9 @@ module.exports = {
     'import/extensions': ['error', 'always', {
       ignorePackages: true,
     }],
+    'no-mixed-operators': ['error', {
+      allowSamePrecedence: true,
+    }],
   },
   overrides: [{
     files: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - refactor(tooltip): rewrite `tooltip` component to use react-portal and unify screenreader / sighted contents;
   - fix(tooltip): resolve issue with `overflow: hidden` truncating tooltip content
   - feat(tooltip): removed `truncate` prop. BREAKING CHANGE: truncation should not be handled by a general component, it should be handled by the existing `className` property or programmatically.
+  - build(deps): Several internal dependencies have been updated for security patches. Thanks, dependabot!
 </details>
 
 ## v0.76.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
     - textarea
   - refactor(tooltip): rewrite `tooltip` component to use react-portal and unify screenreader / sighted contents;
   - fix(tooltip): resolve issue with `overflow: hidden` truncating tooltip content
+  - feat(tooltip): removed `truncate` prop. BREAKING CHANGE: truncation should not be handled by a general component, it should be handled by the existing `className` property or programmatically.
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
     - percentage
     - select
     - textarea
+  - refactor(tooltip): rewrite `tooltip` component to use react-portal and unify screenreader / sighted contents;
+  - fix(tooltip): resolve issue with `overflow: hidden` truncating tooltip content
+
 </details>
 
 ## v0.75.0

--- a/jest.config.setup.files.after.env.js
+++ b/jest.config.setup.files.after.env.js
@@ -6,6 +6,25 @@ beforeAll(() => jestServer.listen({
 afterEach(() => jestServer.resetHandlers());
 afterAll(() => jestServer.close());
 
+beforeEach(() => {
+  // TODO Remove when jest-dom is upgraded.
+  // In the version of jsdom that we have, `getBoundingClientRect` does not return `x` and `y`, which is needed for
+  // the tooltip component. It was recently added to jsdom (https://github.com/jsdom/jsdom/pull/3187), but that
+  // change is not yet reflected in jest-dom.
+  // This is needed for every test which uses the tooltip, it could be added to them individually but having it in one
+  // place only makes it easier to rip out after an upgrade.
+  jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(() => ({
+    width: 120,
+    height: 120,
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    x: 0,
+    y: 0,
+  }));
+});
+
 //   During test development, it might be useful to comment out this error handling. It is useful for ensuring our tests
 //   do not violate propTypes but it can make stack traces much harder to understand.
 

--- a/src/components/form-control/form-control.test.jsx
+++ b/src/components/form-control/form-control.test.jsx
@@ -127,13 +127,21 @@ describe('<FormControl>', () => {
     const tooltip = 'I am an input, short and stout.';
 
     it('displays the tooltip text when the help icon is hovered over', () => {
-      render(<FormControl {...requiredProps} tooltip={tooltip} />);
+      render(
+        <FormControl {...requiredProps} tooltip={tooltip}>
+          <input id="test-id" aria-describedby="test-id-tooltip" />
+        </FormControl>,
+      );
       user.hover(screen.getByRole('img', { name: 'More information' }));
       expect(screen.getByText(tooltip)).toBeInTheDocument();
     });
 
     it('removes the tooltip when the help icon is unhovered', () => {
-      render(<FormControl {...requiredProps} tooltip={tooltip} />);
+      render(
+        <FormControl {...requiredProps} tooltip={tooltip}>
+          <input id="test-id" aria-describedby="test-id-tooltip" />
+        </FormControl>,
+      );
       user.hover(screen.getByRole('img', { name: 'More information' }));
       user.unhover(screen.getByRole('img', { name: 'More information' }));
       expect(screen.queryByText(tooltip)).not.toBeInTheDocument();

--- a/src/components/help-icon/__snapshots__/help-icon.test.jsx.snap
+++ b/src/components/help-icon/__snapshots__/help-icon.test.jsx.snap
@@ -4,8 +4,7 @@ exports[`HelpIcon direction api allows bottom 1`] = `
 <body>
   <div>
     <div
-      class="tooltip bottom"
-      data-tooltip="Help Text"
+      class="wrapper"
     >
       <svg
         height="18"
@@ -28,8 +27,7 @@ exports[`HelpIcon direction api allows left 1`] = `
 <body>
   <div>
     <div
-      class="tooltip left"
-      data-tooltip="Help Text"
+      class="wrapper"
     >
       <svg
         height="18"
@@ -52,8 +50,7 @@ exports[`HelpIcon direction api allows right 1`] = `
 <body>
   <div>
     <div
-      class="tooltip right"
-      data-tooltip="Help Text"
+      class="wrapper"
     >
       <svg
         height="18"
@@ -76,8 +73,7 @@ exports[`HelpIcon direction api allows top 1`] = `
 <body>
   <div>
     <div
-      class="tooltip top"
-      data-tooltip="Help Text"
+      class="wrapper"
     >
       <svg
         height="18"
@@ -100,8 +96,7 @@ exports[`HelpIcon has defaults 1`] = `
 <body>
   <div>
     <div
-      class="tooltip top"
-      data-tooltip="Help Text"
+      class="wrapper"
     >
       <svg
         height="18"
@@ -124,15 +119,8 @@ exports[`HelpIcon has defaults 2`] = `
 <body>
   <div>
     <div
-      class="tooltip top"
-      data-tooltip="Help Text"
+      class="wrapper"
     >
-      <span
-        class="sr-only"
-        id="help-tooltip"
-      >
-        Help Text
-      </span>
       <svg
         height="18"
         role="img"
@@ -147,5 +135,12 @@ exports[`HelpIcon has defaults 2`] = `
       </svg>
     </div>
   </div>
+  <span
+    class="tooltip top"
+    id="help-tooltip"
+    style="left: 0px; top: -128px;"
+  >
+    Help Text
+  </span>
 </body>
 `;

--- a/src/components/help-icon/__snapshots__/help-icon.test.jsx.snap
+++ b/src/components/help-icon/__snapshots__/help-icon.test.jsx.snap
@@ -4,6 +4,11 @@ exports[`HelpIcon direction api allows bottom 1`] = `
 <body>
   <div>
     <div
+      aria-describedby="help-tooltip"
+    />
+  </div>
+  <div>
+    <div
       class="wrapper"
     >
       <svg
@@ -32,6 +37,11 @@ exports[`HelpIcon direction api allows bottom 1`] = `
 
 exports[`HelpIcon direction api allows left 1`] = `
 <body>
+  <div>
+    <div
+      aria-describedby="help-tooltip"
+    />
+  </div>
   <div>
     <div
       class="wrapper"
@@ -64,6 +74,11 @@ exports[`HelpIcon direction api allows right 1`] = `
 <body>
   <div>
     <div
+      aria-describedby="help-tooltip"
+    />
+  </div>
+  <div>
+    <div
       class="wrapper"
     >
       <svg
@@ -92,6 +107,11 @@ exports[`HelpIcon direction api allows right 1`] = `
 
 exports[`HelpIcon direction api allows top 1`] = `
 <body>
+  <div>
+    <div
+      aria-describedby="help-tooltip"
+    />
+  </div>
   <div>
     <div
       class="wrapper"
@@ -124,6 +144,11 @@ exports[`HelpIcon has defaults 1`] = `
 <body>
   <div>
     <div
+      aria-describedby="help-tooltip"
+    />
+  </div>
+  <div>
+    <div
       class="wrapper"
     >
       <svg
@@ -145,6 +170,11 @@ exports[`HelpIcon has defaults 1`] = `
 
 exports[`HelpIcon has defaults 2`] = `
 <body>
+  <div>
+    <div
+      aria-describedby="help-tooltip"
+    />
+  </div>
   <div>
     <div
       class="wrapper"

--- a/src/components/help-icon/__snapshots__/help-icon.test.jsx.snap
+++ b/src/components/help-icon/__snapshots__/help-icon.test.jsx.snap
@@ -28,7 +28,7 @@ exports[`HelpIcon direction api allows bottom 1`] = `
   <span
     class="tooltip bottom"
     id="help-tooltip"
-    style="left: 0px; top: 128px;"
+    style="--triangle-height: 8px; left: 0px; top: 128px;"
   >
     Help Text
   </span>
@@ -63,7 +63,7 @@ exports[`HelpIcon direction api allows left 1`] = `
   <span
     class="tooltip left"
     id="help-tooltip"
-    style="left: -128px; top: 0px;"
+    style="--triangle-height: 8px; left: -128px; top: 0px;"
   >
     Help Text
   </span>
@@ -98,7 +98,7 @@ exports[`HelpIcon direction api allows right 1`] = `
   <span
     class="tooltip right"
     id="help-tooltip"
-    style="left: 128px; top: 0px;"
+    style="--triangle-height: 8px; left: 128px; top: 0px;"
   >
     Help Text
   </span>
@@ -133,7 +133,7 @@ exports[`HelpIcon direction api allows top 1`] = `
   <span
     class="tooltip top"
     id="help-tooltip"
-    style="left: 0px; top: -128px;"
+    style="--triangle-height: 8px; left: 0px; top: -128px;"
   >
     Help Text
   </span>
@@ -196,7 +196,7 @@ exports[`HelpIcon has defaults 2`] = `
   <span
     class="tooltip top"
     id="help-tooltip"
-    style="left: 0px; top: -128px;"
+    style="--triangle-height: 8px; left: 0px; top: -128px;"
   >
     Help Text
   </span>

--- a/src/components/help-icon/__snapshots__/help-icon.test.jsx.snap
+++ b/src/components/help-icon/__snapshots__/help-icon.test.jsx.snap
@@ -20,6 +20,13 @@ exports[`HelpIcon direction api allows bottom 1`] = `
       </svg>
     </div>
   </div>
+  <span
+    class="tooltip bottom"
+    id="help-tooltip"
+    style="left: 0px; top: 128px;"
+  >
+    Help Text
+  </span>
 </body>
 `;
 
@@ -43,6 +50,13 @@ exports[`HelpIcon direction api allows left 1`] = `
       </svg>
     </div>
   </div>
+  <span
+    class="tooltip left"
+    id="help-tooltip"
+    style="left: -128px; top: 0px;"
+  >
+    Help Text
+  </span>
 </body>
 `;
 
@@ -66,6 +80,13 @@ exports[`HelpIcon direction api allows right 1`] = `
       </svg>
     </div>
   </div>
+  <span
+    class="tooltip right"
+    id="help-tooltip"
+    style="left: 128px; top: 0px;"
+  >
+    Help Text
+  </span>
 </body>
 `;
 
@@ -89,6 +110,13 @@ exports[`HelpIcon direction api allows top 1`] = `
       </svg>
     </div>
   </div>
+  <span
+    class="tooltip top"
+    id="help-tooltip"
+    style="left: 0px; top: -128px;"
+  >
+    Help Text
+  </span>
 </body>
 `;
 

--- a/src/components/help-icon/help-icon.test.jsx
+++ b/src/components/help-icon/help-icon.test.jsx
@@ -10,6 +10,11 @@ describe('HelpIcon', () => {
     text: 'Help Text',
   };
 
+  // There needs to be something on the DOM that the tooltip is describing, so render a dummy div for each test.
+  beforeEach(() => {
+    render(<div aria-describedby={requiredProps.id} />);
+  });
+
   it('has defaults', () => {
     render(<HelpIcon {...requiredProps} />);
     expect(document.body).toMatchSnapshot();

--- a/src/components/help-icon/help-icon.test.jsx
+++ b/src/components/help-icon/help-icon.test.jsx
@@ -44,21 +44,25 @@ describe('HelpIcon', () => {
   describe('direction api', () => {
     it('allows top', () => {
       render(<HelpIcon {...requiredProps} direction="top" />);
+      user.hover(screen.getByTitle('Icon Label'));
       expect(document.body).toMatchSnapshot();
     });
 
     it('allows bottom', () => {
       render(<HelpIcon {...requiredProps} direction="bottom" />);
+      user.hover(screen.getByTitle('Icon Label'));
       expect(document.body).toMatchSnapshot();
     });
 
     it('allows left', () => {
       render(<HelpIcon {...requiredProps} direction="left" />);
+      user.hover(screen.getByTitle('Icon Label'));
       expect(document.body).toMatchSnapshot();
     });
 
     it('allows right', () => {
       render(<HelpIcon {...requiredProps} direction="right" />);
+      user.hover(screen.getByTitle('Icon Label'));
       expect(document.body).toMatchSnapshot();
     });
   });

--- a/src/components/icon/icon.jsx
+++ b/src/components/icon/icon.jsx
@@ -8,6 +8,7 @@ export default function Icon(props) {
 
   return (
     <svg
+      aria-describedby={props.describedBy}
       aria-labelledby={props.labelledBy}
       className={props.className}
       height={height}
@@ -26,6 +27,7 @@ Icon.propTypes = {
     id: PropTypes.string,
     viewBox: PropTypes.string,
   }).isRequired,
+  describedBy: PropTypes.string,
   id: PropTypes.string,
   label: PropTypes.string.isRequired,
   labelledBy: PropTypes.string,
@@ -33,6 +35,7 @@ Icon.propTypes = {
 
 Icon.defaultProps = {
   className: undefined,
+  describedBy: undefined,
   id: undefined,
   labelledBy: undefined,
 };

--- a/src/components/icon/icon.test.jsx
+++ b/src/components/icon/icon.test.jsx
@@ -81,4 +81,16 @@ describe('Icon', () => {
       expect(screen.getByLabelText('Unique label')).toBeInTheDocument();
     });
   });
+
+  describe('describedBy prop API', () => {
+    it('can be set', () => {
+      render((
+        <React.Fragment>
+          <span id="help-id">Help Text</span>
+          <Icon {...requiredProps} describedBy="help-id" />
+        </React.Fragment>
+      ));
+      expect(screen.getByRole('img', { name: 'Test label' })).toHaveDescription('Help Text');
+    });
+  });
 });

--- a/src/components/input/input.md
+++ b/src/components/input/input.md
@@ -13,7 +13,3 @@
 ```js
 <Input id={uuid.v4()} label="Read-only / disabled example" readOnly />
 ```
-
-```js
-<Input id={uuid.v4()} label="An example with extra information" tooltip="Fill this input with some information please" />
-```

--- a/src/components/tooltip/__snapshots__/tooltip.test.jsx.snap
+++ b/src/components/tooltip/__snapshots__/tooltip.test.jsx.snap
@@ -90,23 +90,3 @@ exports[`tooltip has defaults 2`] = `
   </span>
 </body>
 `;
-
-exports[`tooltip truncate api adds the class if true 1`] = `
-<span
-  class="tooltip top truncate"
-  id="my-component-tooltip"
-  style="--triangle-height: 8px; left: 0px; top: -128px;"
->
-  Help Text
-</span>
-`;
-
-exports[`tooltip truncate api does not add the class if false 1`] = `
-<span
-  class="tooltip top"
-  id="my-component-tooltip"
-  style="--triangle-height: 8px; left: 0px; top: -128px;"
->
-  Help Text
-</span>
-`;

--- a/src/components/tooltip/__snapshots__/tooltip.test.jsx.snap
+++ b/src/components/tooltip/__snapshots__/tooltip.test.jsx.snap
@@ -4,8 +4,7 @@ exports[`tooltip className api can be overridden 1`] = `
 <body>
   <div>
     <div
-      class="my-dope-class top"
-      data-tooltip="Help Text"
+      class="wrapper"
     >
       <div
         aria-describedby="my-component-tooltip"
@@ -22,8 +21,7 @@ exports[`tooltip direction api allows bottom 1`] = `
 <body>
   <div>
     <div
-      class="tooltip bottom"
-      data-tooltip="Help Text"
+      class="wrapper"
     >
       <div
         aria-describedby="my-component-tooltip"
@@ -40,8 +38,7 @@ exports[`tooltip direction api allows left 1`] = `
 <body>
   <div>
     <div
-      class="tooltip left"
-      data-tooltip="Help Text"
+      class="wrapper"
     >
       <div
         aria-describedby="my-component-tooltip"
@@ -58,8 +55,7 @@ exports[`tooltip direction api allows right 1`] = `
 <body>
   <div>
     <div
-      class="tooltip right"
-      data-tooltip="Help Text"
+      class="wrapper"
     >
       <div
         aria-describedby="my-component-tooltip"
@@ -76,8 +72,7 @@ exports[`tooltip direction api allows top 1`] = `
 <body>
   <div>
     <div
-      class="tooltip top"
-      data-tooltip="Help Text"
+      class="wrapper"
     >
       <div
         aria-describedby="my-component-tooltip"
@@ -94,8 +89,7 @@ exports[`tooltip has defaults 1`] = `
 <body>
   <div>
     <div
-      class="tooltip top"
-      data-tooltip="Help Text"
+      class="wrapper"
     >
       <div
         aria-describedby="my-component-tooltip"
@@ -112,15 +106,8 @@ exports[`tooltip has defaults 2`] = `
 <body>
   <div>
     <div
-      class="tooltip top"
-      data-tooltip="Help Text"
+      class="wrapper"
     >
-      <span
-        class="sr-only"
-        id="my-component-tooltip"
-      >
-        Help Text
-      </span>
       <div
         aria-describedby="my-component-tooltip"
         id="my-component"
@@ -129,6 +116,13 @@ exports[`tooltip has defaults 2`] = `
       </div>
     </div>
   </div>
+  <span
+    class="tooltip top"
+    id="my-component-tooltip"
+    style="left: 0px; top: -128px;"
+  >
+    Help Text
+  </span>
 </body>
 `;
 
@@ -136,8 +130,7 @@ exports[`tooltip truncate api adds the class if true 1`] = `
 <body>
   <div>
     <div
-      class="tooltip top truncate"
-      data-tooltip="Help Text"
+      class="wrapper"
     >
       <div
         aria-describedby="my-component-tooltip"
@@ -154,8 +147,7 @@ exports[`tooltip truncate api does not add the class if false 1`] = `
 <body>
   <div>
     <div
-      class="tooltip top"
-      data-tooltip="Help Text"
+      class="wrapper"
     >
       <div
         aria-describedby="my-component-tooltip"

--- a/src/components/tooltip/__snapshots__/tooltip.test.jsx.snap
+++ b/src/components/tooltip/__snapshots__/tooltip.test.jsx.snap
@@ -1,88 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`tooltip className api can be overridden 1`] = `
-<body>
-  <div>
-    <div
-      class="wrapper"
-    >
-      <div
-        aria-describedby="my-component-tooltip"
-        id="my-component"
-      >
-        Child
-      </div>
-    </div>
-  </div>
-</body>
+<span
+  class="my-dope-class top"
+  id="my-component-tooltip"
+  style="left: 0px; top: -128px;"
+>
+  Help Text
+</span>
 `;
 
 exports[`tooltip direction api allows bottom 1`] = `
-<body>
-  <div>
-    <div
-      class="wrapper"
-    >
-      <div
-        aria-describedby="my-component-tooltip"
-        id="my-component"
-      >
-        Child
-      </div>
-    </div>
-  </div>
-</body>
+<span
+  class="tooltip bottom"
+  id="my-component-tooltip"
+  style="left: 0px; top: 128px;"
+>
+  Help Text
+</span>
 `;
 
 exports[`tooltip direction api allows left 1`] = `
-<body>
-  <div>
-    <div
-      class="wrapper"
-    >
-      <div
-        aria-describedby="my-component-tooltip"
-        id="my-component"
-      >
-        Child
-      </div>
-    </div>
-  </div>
-</body>
+<span
+  class="tooltip left"
+  id="my-component-tooltip"
+  style="left: -128px; top: 0px;"
+>
+  Help Text
+</span>
 `;
 
 exports[`tooltip direction api allows right 1`] = `
-<body>
-  <div>
-    <div
-      class="wrapper"
-    >
-      <div
-        aria-describedby="my-component-tooltip"
-        id="my-component"
-      >
-        Child
-      </div>
-    </div>
-  </div>
-</body>
+<span
+  class="tooltip right"
+  id="my-component-tooltip"
+  style="left: 128px; top: 0px;"
+>
+  Help Text
+</span>
 `;
 
 exports[`tooltip direction api allows top 1`] = `
-<body>
-  <div>
-    <div
-      class="wrapper"
-    >
-      <div
-        aria-describedby="my-component-tooltip"
-        id="my-component"
-      >
-        Child
-      </div>
-    </div>
-  </div>
-</body>
+<span
+  class="tooltip top"
+  id="my-component-tooltip"
+  style="left: 0px; top: -128px;"
+>
+  Help Text
+</span>
 `;
 
 exports[`tooltip has defaults 1`] = `
@@ -127,35 +92,21 @@ exports[`tooltip has defaults 2`] = `
 `;
 
 exports[`tooltip truncate api adds the class if true 1`] = `
-<body>
-  <div>
-    <div
-      class="wrapper"
-    >
-      <div
-        aria-describedby="my-component-tooltip"
-        id="my-component"
-      >
-        Child
-      </div>
-    </div>
-  </div>
-</body>
+<span
+  class="tooltip top truncate"
+  id="my-component-tooltip"
+  style="left: 0px; top: -128px;"
+>
+  Help Text
+</span>
 `;
 
 exports[`tooltip truncate api does not add the class if false 1`] = `
-<body>
-  <div>
-    <div
-      class="wrapper"
-    >
-      <div
-        aria-describedby="my-component-tooltip"
-        id="my-component"
-      >
-        Child
-      </div>
-    </div>
-  </div>
-</body>
+<span
+  class="tooltip top"
+  id="my-component-tooltip"
+  style="left: 0px; top: -128px;"
+>
+  Help Text
+</span>
 `;

--- a/src/components/tooltip/__snapshots__/tooltip.test.jsx.snap
+++ b/src/components/tooltip/__snapshots__/tooltip.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`tooltip className api can be overridden 1`] = `
 <span
   class="my-dope-class top"
   id="my-component-tooltip"
-  style="left: 0px; top: -128px;"
+  style="--triangle-height: 8px; left: 0px; top: -128px;"
 >
   Help Text
 </span>
@@ -14,7 +14,7 @@ exports[`tooltip direction api allows bottom 1`] = `
 <span
   class="tooltip bottom"
   id="my-component-tooltip"
-  style="left: 0px; top: 128px;"
+  style="--triangle-height: 8px; left: 0px; top: 128px;"
 >
   Help Text
 </span>
@@ -24,7 +24,7 @@ exports[`tooltip direction api allows left 1`] = `
 <span
   class="tooltip left"
   id="my-component-tooltip"
-  style="left: -128px; top: 0px;"
+  style="--triangle-height: 8px; left: -128px; top: 0px;"
 >
   Help Text
 </span>
@@ -34,7 +34,7 @@ exports[`tooltip direction api allows right 1`] = `
 <span
   class="tooltip right"
   id="my-component-tooltip"
-  style="left: 128px; top: 0px;"
+  style="--triangle-height: 8px; left: 128px; top: 0px;"
 >
   Help Text
 </span>
@@ -44,7 +44,7 @@ exports[`tooltip direction api allows top 1`] = `
 <span
   class="tooltip top"
   id="my-component-tooltip"
-  style="left: 0px; top: -128px;"
+  style="--triangle-height: 8px; left: 0px; top: -128px;"
 >
   Help Text
 </span>
@@ -84,7 +84,7 @@ exports[`tooltip has defaults 2`] = `
   <span
     class="tooltip top"
     id="my-component-tooltip"
-    style="left: 0px; top: -128px;"
+    style="--triangle-height: 8px; left: 0px; top: -128px;"
   >
     Help Text
   </span>
@@ -95,7 +95,7 @@ exports[`tooltip truncate api adds the class if true 1`] = `
 <span
   class="tooltip top truncate"
   id="my-component-tooltip"
-  style="left: 0px; top: -128px;"
+  style="--triangle-height: 8px; left: 0px; top: -128px;"
 >
   Help Text
 </span>
@@ -105,7 +105,7 @@ exports[`tooltip truncate api does not add the class if false 1`] = `
 <span
   class="tooltip top"
   id="my-component-tooltip"
-  style="left: 0px; top: -128px;"
+  style="--triangle-height: 8px; left: 0px; top: -128px;"
 >
   Help Text
 </span>

--- a/src/components/tooltip/tooltip.css
+++ b/src/components/tooltip/tooltip.css
@@ -1,3 +1,4 @@
+/* stylelint-disable css-modules/css-variables */
 @import '../../styles/colors-v2.css';
 @import '../../styles/spacing.css';
 @import '../../styles/typography-v2.css';
@@ -24,8 +25,6 @@
 .bottom::before,
 .left::before,
 .right::before {
-  --triangle-height: var(--spacing-medium);
-
   content: '';
   border: var(--triangle-height) solid transparent; /* stylelint-disable-line mds/colors */
   position: absolute;

--- a/src/components/tooltip/tooltip.css
+++ b/src/components/tooltip/tooltip.css
@@ -54,3 +54,9 @@
   left: calc(-2 * var(--triangle-height));
   top: calc(50% - var(--triangle-height));
 }
+
+.truncate {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}

--- a/src/components/tooltip/tooltip.css
+++ b/src/components/tooltip/tooltip.css
@@ -2,40 +2,17 @@
 @import '../../styles/spacing.css';
 @import '../../styles/typography-v2.css';
 
-/*
-  This css file uses pseudo elements and the triangle hack to render a tooltip.
-  It is adapted from https://chrisbracco.com/a-simple-css-tooltip/.
-
-  General ideas:
-  ::before - the tooltip's triangle         - aligned on the appropriate side, centered on the parent element, adjusted for the triangle's height (see https://stackoverflow.com/questions/7073484/how-do-css-triangles-work)
-  ::after  - the tooltip's text content/box - aligned on the appropriate side, centered on the parent element, adjusted for the content's width, adjusted for the triangle's height
-*/
-
-.tooltip {
-  --triangle-height: 6px;
-  --negative-triangle-height: calc(-1 * var(--triangle-height));
-
+.wrapper {
+  width: fit-content;
   position: relative;
   display: inline-flex;
 }
 
-/* Base styles for the tooltip's direction arrow */
-.tooltip::before {
-  z-index: 1001;
-  border-width: var(--triangle-height);
-  border-style: solid;
-  border-color: transparent;
-  background: transparent;
-  content: "";
-}
-
-/* Base styles for the tooltip's content area */
-.tooltip::after {
-  z-index: 1000;
+.tooltip {
+  position: absolute;
   padding: var(--spacing-medium);
   width: fit-content;
   max-width: calc(10 * var(--spacing-x-large));
-  content: attr(data-tooltip);
   font: var(--mds-type-subtext);
   border-radius: 3px;
   background-color: var(--mds-grey-87);
@@ -43,96 +20,37 @@
   color: var(--white);
 }
 
-.tooltip::before,
-.tooltip::after {
-  position: absolute;
-  visibility: hidden;
-  pointer-events: none;
-}
+.top::before,
+.bottom::before,
+.left::before,
+.right::before {
+  --triangle-height: var(--spacing-medium);
 
-.tooltip:hover::before,
-.tooltip:hover::after,
-.tooltip:focus-within::before,
-.tooltip:focus-within::after {
-  visibility: visible;
-  opacity: 1;
+  content: '';
+  border: var(--triangle-height) solid transparent; /* stylelint-disable-line mds/colors */
+  position: absolute;
 }
 
 .top::before {
-  bottom: 100%;
-  left: 50%;
-  transform: translateX(-50%) translateY(var(--triangle-height));
   border-top-color: var(--mds-grey-87);
-}
-
-.top::after {
-  bottom: calc(100% - 1px);
-  left: 50%;
-  transform: translateX(-50%) translateY(var(--negative-triangle-height));
+  left: calc(50% - var(--triangle-height));
+  top: 100%;
 }
 
 .bottom::before {
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%) translateY(var(--negative-triangle-height));
-  border-top-color: transparent;
   border-bottom-color: var(--mds-grey-87);
-}
-
-.bottom::after {
-  top: calc(100% - 1px);
-  left: 50%;
-  transform: translateX(-50%) translateY(var(--triangle-height));
+  left: calc(50% - var(--triangle-height));
+  top: calc(-2 * var(--triangle-height));
 }
 
 .left::before {
-  top: 50%;
-  right: 100%;
-  transform: translateX(var(--triangle-height)) translateY(-50%);
-  border-top-color: transparent;
   border-left-color: var(--mds-grey-87);
-}
-
-.left::after {
-  top: 50%;
-  right: calc(100% - 1px);
-  transform: translateX(var(--negative-triangle-height)) translateY(-50%);
+  left: 100%;
+  top: calc(50% - var(--triangle-height));
 }
 
 .right::before {
-  top: 50%;
-  left: 100%;
-  transform: translateX(var(--negative-triangle-height)) translateY(-50%);
-  border-top-color: transparent;
   border-right-color: var(--mds-grey-87);
-}
-
-.right::after {
-  top: 50%;
-  left: 100%;
-  transform: translateX(var(--triangle-height)) translateY(-50%);
-}
-
-.truncate::after {
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-}
-
-/*
-  This class is used to hide the DOM node content off of the screen for sighted users, but still allows
-  screen readers to use it.
-
-  This way we can continue to use the CSS `content` hack for sighted users (which keeps the CSS for the
-  tooltip simple and address 99%+ of tooltip needs), without losing testability or accessibility.
-
-  For more information, see https://webaim.org/techniques/css/invisiblecontent/#offscreen
- */
-.sr-only {
-  position: absolute;
-  left: -10000px;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
+  left: calc(-2 * var(--triangle-height));
+  top: calc(50% - var(--triangle-height));
 }

--- a/src/components/tooltip/tooltip.css
+++ b/src/components/tooltip/tooltip.css
@@ -53,9 +53,3 @@
   left: calc(-2 * var(--triangle-height));
   top: calc(50% - var(--triangle-height));
 }
-
-.truncate {
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-}

--- a/src/components/tooltip/tooltip.jsx
+++ b/src/components/tooltip/tooltip.jsx
@@ -29,7 +29,7 @@ export default function Tooltip({
   }, []);
 
   // keep the div so enabling/disabling doesn't affect the dom tree or styles
-  if (disabled) return <div>{children}</div>;
+  if (disabled) return <div className={styles.wrapper}>{children}</div>;
 
   const classNames = [className];
   if (direction === 'top') classNames.push(styles.top);

--- a/src/components/tooltip/tooltip.jsx
+++ b/src/components/tooltip/tooltip.jsx
@@ -24,7 +24,7 @@ export default function Tooltip({
   const { position, visible, show, hide } = useTooltipPositioning({ tooltipRef, triangleHeight, direction });
 
   useLayoutEffect(() => {
-    if (disabled || document.querySelector(`[aria-describedby="${id}"]`)) return;
+    if (disabled || document.querySelector('[aria-describedby]', id)) return;
 
     throw new Error('<Tooltip> was used without an element on the DOM being described by it. ' +
       'Please add `aria-describedby` to the element this tooltip is being used to describe.');

--- a/src/components/tooltip/tooltip.jsx
+++ b/src/components/tooltip/tooltip.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import styles from './tooltip.css';
@@ -22,6 +22,13 @@ export default function Tooltip({
 
   const tooltipRef = useRef();
   const { position, visible, show, hide } = useTooltipPositioning({ tooltipRef, triangleHeight, direction });
+
+  useLayoutEffect(() => {
+    if (disabled || document.querySelector(`[aria-describedby="${id}"]`)) return;
+
+    throw new Error('<Tooltip> was used without an element on the DOM being described by it. ' +
+      'Please add `aria-describedby` to the element this tooltip is being used to describe.');
+  }, []);
 
   // keep the div so enabling/disabling doesn't affect the dom tree or styles
   if (disabled) return <div>{children}</div>;

--- a/src/components/tooltip/tooltip.jsx
+++ b/src/components/tooltip/tooltip.jsx
@@ -32,6 +32,8 @@ export default function Tooltip({
   else if (direction === 'left') classNames.push(styles.left);
   else if (direction === 'right') classNames.push(styles.right);
 
+  if (truncate) classNames.push(styles.truncate);
+
   return (
     <div
       className={styles.wrapper}

--- a/src/components/tooltip/tooltip.jsx
+++ b/src/components/tooltip/tooltip.jsx
@@ -14,7 +14,6 @@ export default function Tooltip({
   disabled,
   id,
   text,
-  truncate,
 }) {
   // size of the triangle in pixels
   const triangleHeight = 8;
@@ -37,8 +36,6 @@ export default function Tooltip({
   else if (direction === 'bottom') classNames.push(styles.bottom);
   else if (direction === 'left') classNames.push(styles.left);
   else if (direction === 'right') classNames.push(styles.right);
-
-  if (truncate) classNames.push(styles.truncate);
 
   return (
     <div
@@ -78,12 +75,10 @@ Tooltip.propTypes = {
   id: PropTypes.string.isRequired,
   /** The text inside of the tooltip. Tooltip text should be concise and kept to 1-2 short sentences. */
   text: PropTypes.string.isRequired,
-  truncate: PropTypes.bool,
 };
 
 Tooltip.defaultProps = {
   className: styles.tooltip,
   direction: 'top',
   disabled: false,
-  truncate: false,
 };

--- a/src/components/tooltip/tooltip.jsx
+++ b/src/components/tooltip/tooltip.jsx
@@ -16,8 +16,7 @@ export default function Tooltip({
   text,
   truncate,
 }) {
-  // size of the triangle in pixels; this should be the same as teh value in the linked stylesheet
-  // TODO is there a way to share the variable so its only in one place
+  // size of the triangle in pixels
   const triangleHeight = 8;
 
   const tooltipRef = useRef();
@@ -54,7 +53,10 @@ export default function Tooltip({
         <span
           id={id}
           className={classNames.join(' ')}
-          style={position}
+          style={{
+            '--triangle-height': `${triangleHeight}px`,
+            ...position,
+          }}
           ref={tooltipRef}
         >
           {text}

--- a/src/components/tooltip/tooltip.md
+++ b/src/components/tooltip/tooltip.md
@@ -14,6 +14,8 @@ However, the tooltip is intended to be usable in conjunction with any children o
 
 **Regardless, it is _imperative_ that there is an `aria-describedby` in the tooltipped component with the value of the `id` provided to `<Tooltip>`. This sets up the accessible relationship which help screenreaders and other assistive technology**.
 
+There is a `useLayoutEffect` hook on the tooltip that will scan the document for a linking element and raise an error if it is not found.
+
 ```jsx
 import Tooltip from "./tooltip.jsx";
 

--- a/src/components/tooltip/tooltip.md
+++ b/src/components/tooltip/tooltip.md
@@ -6,7 +6,7 @@ import Icon from "../icon/icon.jsx";
 import cautionSvg from '../../svgs/caution.svg';
 
 <Tooltip text="and here that beautiful text is" id="help-tooltip" direction="top">
-  <Icon label="caution" icon={cautionSvg} aria-describedby="help-tooltip" />
+  <Icon label="caution" icon={cautionSvg} describedBy="help-tooltip" />
 </Tooltip>
 ```
 

--- a/src/components/tooltip/tooltip.md
+++ b/src/components/tooltip/tooltip.md
@@ -45,17 +45,3 @@ import Tooltip from "./tooltip.jsx";
     <input id="texty-lad" aria-describedby="texty-lad-tooltip" />
 </Tooltip>
 ```
-
-Finally, you can also use the `truncate` prop to limit tooltip length.
-
-In general, this is not recommended. Tooltips should be kept short and concise. If something needs a particularly long and verbose set of text, it should be somewhere other than a tooltip. However, in cases where tooltips render user-entered data, this is not always achievable. Use this option mindfully.
-
-```jsx
-import Tooltip from "./tooltip.jsx";
-
-const terms = "By using this Site, you agree to be bound by, and to comply with, these Terms and Conditions. If you do not agree to these Terms and Conditions, please do not use this site.";
-
-<Tooltip text={terms} id="terms-n-conditions-tooltip" truncate>
-    <input type="checkbox" id="terms-n-conditions" aria-describedby="terms-n-conditions-tooltip" />
-</Tooltip>
-```

--- a/src/components/tooltip/tooltip.test.jsx
+++ b/src/components/tooltip/tooltip.test.jsx
@@ -126,20 +126,6 @@ describe('tooltip', () => {
     });
   });
 
-  describe('truncate api', () => {
-    it('adds the class if true', () => {
-      render(<Tooltip {...requiredProps} truncate={true} />);
-      user.hover(screen.getByText('Child'));
-      expect(document.getElementById(requiredProps.id)).toMatchSnapshot();
-    });
-
-    it('does not add the class if false', () => {
-      render(<Tooltip {...requiredProps} truncate={false} />);
-      user.hover(screen.getByText('Child'));
-      expect(document.getElementById(requiredProps.id)).toMatchSnapshot();
-    });
-  });
-
   describe('className api', () => {
     it('can be overridden', () => {
       render(<Tooltip {...requiredProps} className="my-dope-class" />);

--- a/src/components/tooltip/tooltip.test.jsx
+++ b/src/components/tooltip/tooltip.test.jsx
@@ -18,6 +18,17 @@ describe('tooltip', () => {
     expect(document.body).toMatchSnapshot();
   });
 
+  it('errors if the tooltip is not describing any elements', () => {
+    expect(() => {
+      render(
+        <Tooltip {...requiredProps}>
+          <input />
+        </Tooltip>,
+      );
+    }).toThrowError('<Tooltip> was used without an element on the DOM being described by it. ' +
+      'Please add `aria-describedby` to the element this tooltip is being used to describe.');
+  });
+
   describe('hovering behavior', () => {
     it('does not render the tooltip unless the child is hovered', () => {
       render(<Tooltip {...requiredProps} />);

--- a/src/components/tooltip/tooltip.test.jsx
+++ b/src/components/tooltip/tooltip.test.jsx
@@ -19,6 +19,10 @@ describe('tooltip', () => {
   });
 
   it('errors if the tooltip is not describing any elements', () => {
+    /* eslint-disable no-console */
+    const originalConsoleError = console.error;
+    console.error = jest.fn();
+
     expect(() => {
       render(
         <Tooltip {...requiredProps}>
@@ -27,6 +31,9 @@ describe('tooltip', () => {
       );
     }).toThrowError('<Tooltip> was used without an element on the DOM being described by it. ' +
       'Please add `aria-describedby` to the element this tooltip is being used to describe.');
+
+    expect(console.error).toHaveBeenCalled();
+    console.error = originalConsoleError;
   });
 
   describe('hovering behavior', () => {

--- a/src/components/tooltip/tooltip.test.jsx
+++ b/src/components/tooltip/tooltip.test.jsx
@@ -19,9 +19,8 @@ describe('tooltip', () => {
   });
 
   it('errors if the tooltip is not describing any elements', () => {
-    /* eslint-disable no-console */
-    const originalConsoleError = console.error;
-    console.error = jest.fn();
+    const originalConsoleError = window.console.error;
+    window.console.error = jest.fn();
 
     expect(() => {
       render(
@@ -32,8 +31,8 @@ describe('tooltip', () => {
     }).toThrowError('<Tooltip> was used without an element on the DOM being described by it. ' +
       'Please add `aria-describedby` to the element this tooltip is being used to describe.');
 
-    expect(console.error).toHaveBeenCalled();
-    console.error = originalConsoleError;
+    expect(window.console.error).toHaveBeenCalled();
+    window.console.error = originalConsoleError;
   });
 
   describe('hovering behavior', () => {

--- a/src/components/tooltip/tooltip.test.jsx
+++ b/src/components/tooltip/tooltip.test.jsx
@@ -85,41 +85,48 @@ describe('tooltip', () => {
   describe('direction api', () => {
     it('allows top', () => {
       render(<Tooltip {...requiredProps} direction="top" />);
-      expect(document.body).toMatchSnapshot();
+      user.hover(screen.getByText('Child'));
+      expect(document.getElementById(requiredProps.id)).toMatchSnapshot();
     });
 
     it('allows bottom', () => {
       render(<Tooltip {...requiredProps} direction="bottom" />);
-      expect(document.body).toMatchSnapshot();
+      user.hover(screen.getByText('Child'));
+      expect(document.getElementById(requiredProps.id)).toMatchSnapshot();
     });
 
     it('allows left', () => {
       render(<Tooltip {...requiredProps} direction="left" />);
-      expect(document.body).toMatchSnapshot();
+      user.hover(screen.getByText('Child'));
+      expect(document.getElementById(requiredProps.id)).toMatchSnapshot();
     });
 
     it('allows right', () => {
       render(<Tooltip {...requiredProps} direction="right" />);
-      expect(document.body).toMatchSnapshot();
+      user.hover(screen.getByText('Child'));
+      expect(document.getElementById(requiredProps.id)).toMatchSnapshot();
     });
   });
 
   describe('truncate api', () => {
     it('adds the class if true', () => {
-      render(<Tooltip {...requiredProps} truncate />);
-      expect(document.body).toMatchSnapshot();
+      render(<Tooltip {...requiredProps} truncate={true} />);
+      user.hover(screen.getByText('Child'));
+      expect(document.getElementById(requiredProps.id)).toMatchSnapshot();
     });
 
     it('does not add the class if false', () => {
       render(<Tooltip {...requiredProps} truncate={false} />);
-      expect(document.body).toMatchSnapshot();
+      user.hover(screen.getByText('Child'));
+      expect(document.getElementById(requiredProps.id)).toMatchSnapshot();
     });
   });
 
   describe('className api', () => {
     it('can be overridden', () => {
       render(<Tooltip {...requiredProps} className="my-dope-class" />);
-      expect(document.body).toMatchSnapshot();
+      user.hover(screen.getByText('Child'));
+      expect(document.getElementById(requiredProps.id)).toMatchSnapshot();
     });
   });
 });

--- a/src/components/tooltip/use-tooltip-positioning.js
+++ b/src/components/tooltip/use-tooltip-positioning.js
@@ -21,7 +21,7 @@ export default function useTooltipPositioning({
     const sourceRect = target.getBoundingClientRect();
 
     // Start from the top-left of the thing we want the tooltip to "open" from.
-    const sourceX = sourceRect.x;
+    const sourceX = sourceRect.x + window.scrollX;
     const sourceY = sourceRect.y + window.scrollY;
     const tooltipText = tooltipRef.current.getBoundingClientRect();
 

--- a/src/components/tooltip/use-tooltip-positioning.js
+++ b/src/components/tooltip/use-tooltip-positioning.js
@@ -1,0 +1,54 @@
+import { useLayoutEffect, useState } from 'react';
+
+export default function useTooltipPositioning({
+  tooltipRef,
+  triangleHeight,
+  direction = 'top',
+}) {
+  const [target, setTarget] = useState(null);
+  const [position, setPosition] = useState(null);
+
+  const show = event => setTarget(event.target);
+  const hide = () => setTarget(null);
+
+  useLayoutEffect(() => {
+    if (!target) {
+      setPosition(null);
+      return;
+    }
+
+    // "source" in this context is where the tooltip appears to being opening from
+    const sourceRect = target.getBoundingClientRect();
+
+    // Start from the top-left of the thing we want the tooltip to "open" from.
+    const sourceX = sourceRect.x;
+    const sourceY = sourceRect.y + window.scrollY;
+    const tooltipText = tooltipRef.current.getBoundingClientRect();
+
+    let left;
+    let top;
+
+    if (direction === 'top') {
+      left = sourceX + (sourceRect.width / 2) - (tooltipText.width / 2);
+      top = sourceY - tooltipText.height - triangleHeight;
+    } else if (direction === 'bottom') {
+      left = sourceX + (sourceRect.width / 2) - (tooltipText.width / 2);
+      top = sourceY + sourceRect.height + triangleHeight;
+    } else if (direction === 'left') {
+      left = sourceX - tooltipText.width - triangleHeight;
+      top = sourceY + (sourceRect.height / 2) - (tooltipText.height / 2);
+    } else if (direction === 'right') {
+      left = sourceX + sourceRect.width + triangleHeight;
+      top = sourceY + (sourceRect.height / 2) - (tooltipText.height / 2);
+    }
+
+    setPosition({ left, top });
+  }, [target]);
+
+  return {
+    visible: !!target,
+    position,
+    show,
+    hide,
+  };
+}

--- a/src/components/tooltip/use-tooltip-positioning.test.js
+++ b/src/components/tooltip/use-tooltip-positioning.test.js
@@ -1,0 +1,124 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import useTooltipPositioning from './use-tooltip-positioning.js';
+
+describe('use-tooltip-positioning', () => {
+  const requiredProps = {
+    triangleHeight: 6,
+    tooltipRef: { current: { getBoundingClientRect: () => ({}) } },
+  };
+
+  it('visible is false initially', () => {
+    const { result } = renderHook(() => useTooltipPositioning(requiredProps));
+    expect(result.current.visible).toBe(false);
+  });
+
+  it('visible is true after show is called', () => {
+    const target = { getBoundingClientRect: () => ({}) };
+
+    const { result } = renderHook(() => useTooltipPositioning(requiredProps));
+    act(() => result.current.show({ target }));
+    expect(result.current.visible).toBe(true);
+  });
+
+  it('is not visible after hide is called', () => {
+    const target = { getBoundingClientRect: () => ({}) };
+
+    const { result } = renderHook(() => useTooltipPositioning(requiredProps));
+    act(() => result.current.show({ target }));
+    act(() => result.current.hide());
+    expect(result.current.visible).toBe(false);
+  });
+
+  describe('position and direction', () => {
+    const tooltipRect = {
+      height: 20,
+      width: 40,
+      x: 60,
+      y: 80,
+    };
+    const triangleHeight = 5;
+    const sourceRect = {
+      height: 2,
+      width: 4,
+      x: 6,
+      y: 8,
+    };
+    const target = { getBoundingClientRect: () => (sourceRect) };
+
+    it('direction = top sets the position central horizontally and above vertically', () => {
+      const { result } = renderHook(() => useTooltipPositioning({
+        direction: 'top',
+        triangleHeight,
+        tooltipRef: {
+          current: {
+            getBoundingClientRect: () => tooltipRect,
+          },
+        },
+      }));
+
+      act(() => result.current.show({ target }));
+
+      expect(result.current.position).toEqual({
+        left: sourceRect.x + (sourceRect.width / 2) - (tooltipRect.width / 2),
+        top: sourceRect.y - tooltipRect.height - triangleHeight,
+      });
+    });
+
+    it('direction = bottom sets the position central horizontally and below vertically', () => {
+      const { result } = renderHook(() => useTooltipPositioning({
+        direction: 'bottom',
+        triangleHeight,
+        tooltipRef: {
+          current: {
+            getBoundingClientRect: () => tooltipRect,
+          },
+        },
+      }));
+
+      act(() => result.current.show({ target }));
+
+      expect(result.current.position).toEqual({
+        left: sourceRect.x + (sourceRect.width / 2) - (tooltipRect.width / 2),
+        top: sourceRect.y + sourceRect.height + triangleHeight,
+      });
+    });
+
+    it('direction = left sets the position to the left horizontally and centered vertically', () => {
+      const { result } = renderHook(() => useTooltipPositioning({
+        direction: 'left',
+        triangleHeight,
+        tooltipRef: {
+          current: {
+            getBoundingClientRect: () => tooltipRect,
+          },
+        },
+      }));
+
+      act(() => result.current.show({ target }));
+
+      expect(result.current.position).toEqual({
+        left: sourceRect.x - tooltipRect.width - triangleHeight,
+        top: sourceRect.y + (sourceRect.height / 2) - (tooltipRect.height / 2),
+      });
+    });
+
+    it('direction = right sets the position to the right horizontally and centered vertically', () => {
+      const { result } = renderHook(() => useTooltipPositioning({
+        direction: 'right',
+        triangleHeight,
+        tooltipRef: {
+          current: {
+            getBoundingClientRect: () => tooltipRect,
+          },
+        },
+      }));
+
+      act(() => result.current.show({ target }));
+
+      expect(result.current.position).toEqual({
+        left: sourceRect.x + sourceRect.width + triangleHeight,
+        top: sourceRect.y + (sourceRect.height / 2) - (tooltipRect.height / 2),
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Motivation
Fix issue in tooltip where `overflow: hidden` makes it impossible for the tooltip to be seen in all of its glory.

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-portal-just-the-tip/
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check
- [x] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
