### PR TITLE
fix(form-control) group label and required together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
     - percentage
     - select
     - textarea
+  - fix(form-control): resolve an issue where tooltip text in a form control was making required move to a new line
 </details>
 
 ## v0.75.0

--- a/src/components/autocompleter/__snapshots__/autocompleter.test.jsx.snap
+++ b/src/components/autocompleter/__snapshots__/autocompleter.test.jsx.snap
@@ -12,13 +12,16 @@ exports[`src/components/autocompleter/autocompleter has defaults 1`] = `
         <div
           class="label-wrapper"
         >
-          <label
+          <div
             class="label"
-            for="test-id"
-            id="test-id-label"
           >
-            Test label
-          </label>
+            <label
+              for="test-id"
+              id="test-id-label"
+            >
+              Test label
+            </label>
+          </div>
         </div>
         <div
           class="control-container"

--- a/src/components/checkbox/__snapshots__/checkbox.test.jsx.snap
+++ b/src/components/checkbox/__snapshots__/checkbox.test.jsx.snap
@@ -9,12 +9,15 @@ exports[`Checkbox has defaults 1`] = `
       <div
         class="label-wrapper"
       >
-        <label
+        <div
           class="label"
-          for="fart"
         >
-          You good?
-        </label>
+          <label
+            for="fart"
+          >
+            You good?
+          </label>
+        </div>
       </div>
       <div
         class="control-container"

--- a/src/components/custom-field-input-currency/__snapshots__/custom-field-input-currency.test.jsx.snap
+++ b/src/components/custom-field-input-currency/__snapshots__/custom-field-input-currency.test.jsx.snap
@@ -9,12 +9,15 @@ exports[`CustomFieldInputCurrency has defaults 1`] = `
       <div
         class="label-wrapper"
       >
-        <label
+        <div
           class="label"
-          for="currency"
         >
-          currency
-        </label>
+          <label
+            for="currency"
+          >
+            currency
+          </label>
+        </div>
       </div>
       <div
         class="control-container"

--- a/src/components/custom-field-input-date/__snapshots__/custom-field-input-date.test.jsx.snap
+++ b/src/components/custom-field-input-date/__snapshots__/custom-field-input-date.test.jsx.snap
@@ -12,13 +12,16 @@ exports[`src/components/custom-field-input-date/custom-field-input-date classNam
         <div
           class="label-wrapper"
         >
-          <label
+          <div
             class="label"
-            for="field-date"
-            id="field-date-label"
           >
-            Field Date
-          </label>
+            <label
+              for="field-date"
+              id="field-date-label"
+            >
+              Field Date
+            </label>
+          </div>
         </div>
         <div
           class="control-container"
@@ -68,13 +71,16 @@ exports[`src/components/custom-field-input-date/custom-field-input-date has defa
         <div
           class="label-wrapper"
         >
-          <label
+          <div
             class="label"
-            for="field-date"
-            id="field-date-label"
           >
-            Field Date
-          </label>
+            <label
+              for="field-date"
+              id="field-date-label"
+            >
+              Field Date
+            </label>
+          </div>
         </div>
         <div
           class="control-container"

--- a/src/components/custom-field-input-multiple-choice/__snapshots__/custom-field-input-multiple-choice.test.jsx.snap
+++ b/src/components/custom-field-input-multiple-choice/__snapshots__/custom-field-input-multiple-choice.test.jsx.snap
@@ -12,13 +12,16 @@ exports[`<CustomFieldInputMultipleChoice> has defaults 1`] = `
         <div
           class="label-wrapper"
         >
-          <label
+          <div
             class="label"
-            for="test-id-autocomplete"
-            id="test-id-label"
           >
-            test label
-          </label>
+            <label
+              for="test-id-autocomplete"
+              id="test-id-label"
+            >
+              test label
+            </label>
+          </div>
         </div>
         <div
           class="control-container"

--- a/src/components/custom-field-input-number/__snapshots__/custom-field-input-number.test.jsx.snap
+++ b/src/components/custom-field-input-number/__snapshots__/custom-field-input-number.test.jsx.snap
@@ -9,12 +9,15 @@ exports[`CustomFieldInputNumber has defaults 1`] = `
       <div
         class="label-wrapper"
       >
-        <label
+        <div
           class="label"
-          for="test-input"
         >
-          Test label
-        </label>
+          <label
+            for="test-input"
+          >
+            Test label
+          </label>
+        </div>
       </div>
       <div
         class="control-container"

--- a/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
+++ b/src/components/custom-field-input-single-choice/__snapshots__/custom-field-input-single-choice.test.jsx.snap
@@ -12,13 +12,16 @@ exports[`src/components/custom-field-input-single-choice/custom-field-input-sing
         <div
           class="label-wrapper"
         >
-          <label
+          <div
             class="label"
-            for="test-id"
-            id="test-id-label"
           >
-            Test label
-          </label>
+            <label
+              for="test-id"
+              id="test-id-label"
+            >
+              Test label
+            </label>
+          </div>
         </div>
         <div
           class="control-container"

--- a/src/components/custom-field-input-text/__snapshots__/custom-field-input-text.test.jsx.snap
+++ b/src/components/custom-field-input-text/__snapshots__/custom-field-input-text.test.jsx.snap
@@ -9,12 +9,15 @@ exports[`CustomFieldInputText has defaults 1`] = `
       <div
         class="label-wrapper"
       >
-        <label
+        <div
           class="label"
-          for="test-input"
         >
-          Test label
-        </label>
+          <label
+            for="test-input"
+          >
+            Test label
+          </label>
+        </div>
       </div>
       <div
         class="control-container"

--- a/src/components/date/__snapshots__/date.test.jsx.snap
+++ b/src/components/date/__snapshots__/date.test.jsx.snap
@@ -12,13 +12,16 @@ exports[`src/components/date/date.test.jsx classNames API sets various class nam
         <div
           class="label-wrapper"
         >
-          <label
+          <div
             class="label"
-            for="test-id"
-            id="test-id-label"
           >
-            Test label
-          </label>
+            <label
+              for="test-id"
+              id="test-id-label"
+            >
+              Test label
+            </label>
+          </div>
         </div>
         <div
           class="control-container"
@@ -68,13 +71,16 @@ exports[`src/components/date/date.test.jsx classNames API sets various class nam
         <div
           class="label-wrapper"
         >
-          <label
+          <div
             class="label"
-            for="test-id"
-            id="test-id-label"
           >
-            Test label
-          </label>
+            <label
+              for="test-id"
+              id="test-id-label"
+            >
+              Test label
+            </label>
+          </div>
         </div>
         <div
           class="control-container"
@@ -660,13 +666,16 @@ exports[`src/components/date/date.test.jsx has defaults 1`] = `
         <div
           class="label-wrapper"
         >
-          <label
+          <div
             class="label"
-            for="test-id"
-            id="test-id-label"
           >
-            Test label
-          </label>
+            <label
+              for="test-id"
+              id="test-id-label"
+            >
+              Test label
+            </label>
+          </div>
         </div>
         <div
           class="control-container"

--- a/src/components/form-control/__snapshots__/form-control.test.jsx.snap
+++ b/src/components/form-control/__snapshots__/form-control.test.jsx.snap
@@ -9,12 +9,15 @@ exports[`<FormControl> has defaults 1`] = `
       <div
         class="label-wrapper"
       >
-        <label
+        <div
           class="label"
-          for="test-id"
         >
-          Test label
-        </label>
+          <label
+            for="test-id"
+          >
+            Test label
+          </label>
+        </div>
       </div>
       <div
         class="control-container"

--- a/src/components/form-control/form-control.css
+++ b/src/components/form-control/form-control.css
@@ -14,13 +14,7 @@
 }
 
 .required {
-  composes: label;
   margin-left: var(--spacing-small);
-}
-
-.invalid-required {
-  composes: required;
-  color: var(--mds-red-text);
 }
 
 .control-container {

--- a/src/components/form-control/form-control.css
+++ b/src/components/form-control/form-control.css
@@ -4,17 +4,14 @@
 
 .label {
   color: var(--mds-grey-54);
-  display: inline;
+  display: inline-flex;
   font: var(--mds-type-subtext);
+  column-gap: var(--spacing-small);
 }
 
 .invalid-label {
   composes: label;
   color: var(--mds-red-text);
-}
-
-.required {
-  margin-left: var(--spacing-small);
 }
 
 .control-container {

--- a/src/components/form-control/form-control.jsx
+++ b/src/components/form-control/form-control.jsx
@@ -9,12 +9,6 @@ function getLabelClassName(error, readOnly) {
   return styles.label;
 }
 
-function getRequiredClassName(error, readOnly) {
-  if (isInvalid(error, readOnly)) return styles['invalid-required'];
-
-  return styles.required;
-}
-
 function isInvalid(error, readOnly) {
   return !!error && !readOnly;
 }
@@ -23,22 +17,23 @@ export default function FormControl(props) {
   return (
     <div className={props.className} onKeyDown={props.onKeyDown} role="presentation">
       <div className={styles['label-wrapper']}>
-        <label
-          className={getLabelClassName(props.error, props.readOnly)}
-          htmlFor={props.id}
-          id={props.labelId}
-        >
-          {props.label}
-        </label>
+        <div className={getLabelClassName(props.error, props.readOnly)}>
+          <label
+            htmlFor={props.id}
+            id={props.labelId}
+          >
+            {props.label}
+          </label>
+          {props.required &&
+            <span className={styles.required}>
+              (Required)
+            </span>
+          }
+        </div>
         {!!props.tooltip && (
-          <HelpIcon text={props.tooltip} label="More information" id={`${props.id}-tooltip`} />
+          <HelpIcon id={`${props.id}-tooltip`} label="More information" text={props.tooltip} />
         )}
       </div>
-      {props.required && (
-        <span className={getRequiredClassName(props.error, props.readOnly)}>
-          (Required)
-        </span>
-      )}
       <div className={styles['control-container']}>
         {props.children}
       </div>

--- a/src/components/form-control/form-control.jsx
+++ b/src/components/form-control/form-control.jsx
@@ -24,11 +24,7 @@ export default function FormControl(props) {
           >
             {props.label}
           </label>
-          {props.required &&
-            <span className={styles.required}>
-              (Required)
-            </span>
-          }
+          {props.required && '(Required)'}
         </div>
         {!!props.tooltip && (
           <HelpIcon id={`${props.id}-tooltip`} label="More information" text={props.tooltip} />

--- a/src/components/input/__snapshots__/input.test.jsx.snap
+++ b/src/components/input/__snapshots__/input.test.jsx.snap
@@ -10,12 +10,15 @@ exports[`Input cssContainer API sets input container className 1`] = `
       <div
         class="label-wrapper"
       >
-        <label
+        <div
           class="label"
-          for="foo"
         >
-          the label
-        </label>
+          <label
+            for="foo"
+          >
+            the label
+          </label>
+        </div>
       </div>
       <div
         class="control-container"
@@ -42,12 +45,15 @@ exports[`Input has defaults 1`] = `
       <div
         class="label-wrapper"
       >
-        <label
+        <div
           class="label"
-          for="foo"
         >
-          the label
-        </label>
+          <label
+            for="foo"
+          >
+            the label
+          </label>
+        </div>
       </div>
       <div
         class="control-container"

--- a/src/components/multi-autocompleter/__snapshots__/multi-autocompleter.test.jsx.snap
+++ b/src/components/multi-autocompleter/__snapshots__/multi-autocompleter.test.jsx.snap
@@ -13,13 +13,16 @@ exports[`<MultiAutocompleter> className API uses class name provided 1`] = `
         <div
           class="label-wrapper"
         >
-          <label
+          <div
             class="label"
-            for="test-id-autocomplete"
-            id="test-id-label"
           >
-            test label
-          </label>
+            <label
+              for="test-id-autocomplete"
+              id="test-id-label"
+            >
+              test label
+            </label>
+          </div>
         </div>
         <div
           class="control-container"
@@ -85,13 +88,16 @@ exports[`<MultiAutocompleter> has defaults 1`] = `
         <div
           class="label-wrapper"
         >
-          <label
+          <div
             class="label"
-            for="test-id-autocomplete"
-            id="test-id-label"
           >
-            test label
-          </label>
+            <label
+              for="test-id-autocomplete"
+              id="test-id-label"
+            >
+              test label
+            </label>
+          </div>
         </div>
         <div
           class="control-container"

--- a/src/components/multi-select/__snapshots__/multi-select.test.jsx.snap
+++ b/src/components/multi-select/__snapshots__/multi-select.test.jsx.snap
@@ -13,13 +13,16 @@ exports[`<MultiSelect> classNames API uses class name overrides provided 1`] = `
         <div
           class="label-wrapper"
         >
-          <label
+          <div
             class="label"
-            for="test-id-autocomplete"
-            id="test-id-label"
           >
-            test label
-          </label>
+            <label
+              for="test-id-autocomplete"
+              id="test-id-label"
+            >
+              test label
+            </label>
+          </div>
         </div>
         <div
           class="control-container"
@@ -85,13 +88,16 @@ exports[`<MultiSelect> has defaults 1`] = `
         <div
           class="label-wrapper"
         >
-          <label
+          <div
             class="label"
-            for="test-id-autocomplete"
-            id="test-id-label"
           >
-            test label
-          </label>
+            <label
+              for="test-id-autocomplete"
+              id="test-id-label"
+            >
+              test label
+            </label>
+          </div>
         </div>
         <div
           class="control-container"

--- a/src/components/number/__snapshots__/number.test.jsx.snap
+++ b/src/components/number/__snapshots__/number.test.jsx.snap
@@ -9,12 +9,15 @@ exports[`Number has defaults 1`] = `
       <div
         class="label-wrapper"
       >
-        <label
+        <div
           class="label"
-          for="test-component"
         >
-          Test Component
-        </label>
+          <label
+            for="test-component"
+          >
+            Test Component
+          </label>
+        </div>
       </div>
       <div
         class="control-container"

--- a/src/components/percentage/__snapshots__/percentage.test.jsx.snap
+++ b/src/components/percentage/__snapshots__/percentage.test.jsx.snap
@@ -10,12 +10,15 @@ exports[`Percentage has defaults 1`] = `
       <div
         class="label-wrapper"
       >
-        <label
+        <div
           class="label"
-          for="foo"
         >
-          the label
-        </label>
+          <label
+            for="foo"
+          >
+            the label
+          </label>
+        </div>
       </div>
       <div
         class="control-container"

--- a/src/components/select/__snapshots__/select.test.jsx.snap
+++ b/src/components/select/__snapshots__/select.test.jsx.snap
@@ -12,13 +12,16 @@ exports[`src/components/select/select has defaults 1`] = `
         <div
           class="label-wrapper"
         >
-          <label
+          <div
             class="label"
-            for="test-id"
-            id="test-id-label"
           >
-            Test label
-          </label>
+            <label
+              for="test-id"
+              id="test-id-label"
+            >
+              Test label
+            </label>
+          </div>
         </div>
         <div
           class="control-container"

--- a/src/components/textarea/__snapshots__/textarea.test.jsx.snap
+++ b/src/components/textarea/__snapshots__/textarea.test.jsx.snap
@@ -9,12 +9,15 @@ exports[`Textarea has defaults 1`] = `
       <div
         class="label-wrapper"
       >
-        <label
+        <div
           class="label"
-          for="foo"
         >
-          the label
-        </label>
+          <label
+            for="foo"
+          >
+            the label
+          </label>
+        </div>
       </div>
       <div
         class="control-container"


### PR DESCRIPTION
## Motivation
fix(form-control): resolve an issue where tooltip text in a form control was making required move to a new line

## Acceptance Criteria
A `FormControl` with just required text should appear as before.
A `FormControl` with required text and a help icon should have them appear with the label and `Required` reminder text left-justified, with only the help icon right-justified, but all on the same line.

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-required-and-tooltip-should-be-friends/
- [ ] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
