### PR TITLE
`HelpIcon`: remove bad example from docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   </summary>
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
-  - Append new items to make git merging easier.=
+  - Append new items to make git merging easier.
+  - docs(help-icon): removed a nonsensical example that did not describe anything
 </details>
 
 ## v0.78.0

--- a/src/components/help-icon/help-icon.md
+++ b/src/components/help-icon/help-icon.md
@@ -2,19 +2,7 @@ HelpIcon is a simple prebaked SVG and tooltip, as it is the standard way to demo
 
 #### Basic Usage
 
-```jsx
-import HelpIcon from "./help-icon.jsx";
-
-<HelpIcon 
-  text="This is the text that appears from the icon" 
-  label="title text for the SVG" 
-  id="example-tooltip"
-/>
-```
-
-#### In-depth example
-
-More realistically, the `HelpIcon` is going to be used in conjunction with other elements, like inputs or paragraphs.
+`HelpIcon` is intended to be used in conjunction with other elements, like inputs or paragraphs.
 
 Much like with `Tooltip`, please remember to apply `aria-describedby` on the component the help text is related to.
 
@@ -23,7 +11,7 @@ import HelpIcon from "./help-icon.jsx";
 
 <div>
   <label style={{ display: 'block' }} htmlFor="email">Email Address</label>
-  <div style={{ display: 'flex', alignItems: 'center' }}>
+  <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
     <input type="email" id="email" aria-describedby="email-tooltip" />
     <HelpIcon 
       text="Please enter your primary email address." 


### PR DESCRIPTION
## Motivation
Removed a bad example from `HelpIcon`.

`<HelpIcon>` should always be used in conjunction with and related to other elements, to `describe` something in particular. There was an example that did not describe anything, and the recently added `useLayoutEffect` in `Tooltip` that checks for the described element was blowing up.

Since that example didn't really make sense to begin with, I just deleted it entirely.

Before:

![image](https://user-images.githubusercontent.com/3209944/124950586-c8802e00-dfcf-11eb-9112-2fb9f5bcb92c.png)
