### PR TITLE
prevent tooltip "jump" w/ scrollbar + add classNames to help-icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
   - docs(help-icon): removed a nonsensical example that did not describe anything
+  - feat(help-icon): added `classNames` api to provide classes to icon & tooltip
+  - fix(tooltip): prevent tooltip misalignment when scrollbar appears
 </details>
 
 ## v0.78.0

--- a/src/components/help-icon/__snapshots__/help-icon.test.jsx.snap
+++ b/src/components/help-icon/__snapshots__/help-icon.test.jsx.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`HelpIcon classNames api passes class name to the icon 1`] = `
+<svg
+  class="an-icon-class"
+  height="18"
+  role="img"
+  width="18"
+>
+  <title>
+    Icon Label
+  </title>
+  <use
+    xlink:href="#help.svg"
+  />
+</svg>
+`;
+
+exports[`HelpIcon classNames api passes class name to tooltip 1`] = `
+<span
+  class="a-tooltip-class top"
+  id="help-tooltip"
+  style="--triangle-height: 8px; left: 0px; top: -128px;"
+>
+  Help Text
+</span>
+`;
+
 exports[`HelpIcon direction api allows bottom 1`] = `
 <body>
   <div>

--- a/src/components/help-icon/help-icon.jsx
+++ b/src/components/help-icon/help-icon.jsx
@@ -5,19 +5,25 @@ import Icon from '../icon/icon.jsx';
 import helpSvg from '../../svgs/help.svg';
 
 export default function HelpIcon({
+  classNames,
   direction,
   id,
   label,
   text,
 }) {
   return (
-    <Tooltip text={text} direction={direction} id={id}>
-      <Icon label={label} icon={helpSvg} />
+    <Tooltip text={text} direction={direction} id={id} className={classNames.tooltip}>
+      <Icon label={label} icon={helpSvg} className={classNames.icon} />
     </Tooltip>
   );
 }
 
 HelpIcon.propTypes = {
+  /** classes to be applied to the tooltip and icon */
+  classNames: PropTypes.shape({
+    icon: PropTypes.string,
+    tooltip: PropTypes.string,
+  }),
   /** Direction for the tooltip to fly from relative to the icon. */
   direction: Tooltip.propTypes.direction,
   /** The id that the tooltip should be given. The element that this tooltip is describing <strong>MUST</strong> have <code>aria-describedby={id}</code>. */
@@ -29,5 +35,6 @@ HelpIcon.propTypes = {
 };
 
 HelpIcon.defaultProps = {
+  classNames: {},
   direction: Tooltip.defaultProps.direction,
 };

--- a/src/components/help-icon/help-icon.test.jsx
+++ b/src/components/help-icon/help-icon.test.jsx
@@ -71,4 +71,19 @@ describe('HelpIcon', () => {
       expect(document.body).toMatchSnapshot();
     });
   });
+
+  describe('classNames api', () => {
+    it('passes class name to tooltip', () => {
+      const classNames = { tooltip: 'a-tooltip-class' };
+      render(<HelpIcon {...requiredProps} classNames={classNames} />);
+      user.hover(screen.getByTitle('Icon Label'));
+      expect(screen.getByText('Help Text')).toMatchSnapshot();
+    });
+
+    it('passes class name to the icon', () => {
+      const classNames = { icon: 'an-icon-class' };
+      render(<HelpIcon {...requiredProps} classNames={classNames} />);
+      expect(screen.getByRole('img')).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/tooltip/tooltip.css
+++ b/src/components/tooltip/tooltip.css
@@ -53,3 +53,14 @@
   left: calc(-2 * var(--triangle-height));
   top: calc(50% - var(--triangle-height));
 }
+
+/*
+  This is to prevent the tooltip from jumping around when a scrollbar appears / disappears. While adding a style like
+  this only on specific components can definitely cause some intermittent global pollution, the choice was either add
+  it only where it is needed (e.g. the tooltip), or globally everywhere, even when it isn't needed. It _should not_
+  cause much in the way of styling pollution other than preventing thescreen from "jumping" when a scrollbar appears,
+  but that is always possible.
+*/
+html {
+  width: 100vw;
+}


### PR DESCRIPTION
## Motivation
1. Add `classNames` api to the `HelpIcon` component to make styling it easier.
2. Add scrollbar "jump" prevention to the tooltip

## Acceptance Criteria


## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-tooltip-updates/
- [x] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
