### PR TITLE
fix(tooltip): add z index for tooltip so it sits on top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
+  - fix(tooltip): added a z-index to tooltips so they can generally be on top of everything. Tooltips are legal inside of other "stacking" content and should be on top.
 </details>
 
 ## 0.79.0

--- a/src/components/tooltip/tooltip.css
+++ b/src/components/tooltip/tooltip.css
@@ -19,6 +19,7 @@
   background-color: var(--mds-grey-87);
   border-color: var(--mds-grey-87);
   color: var(--white);
+  z-index: 65536; /* a tooltip should be able to sit above modals and other stacked objects */
 }
 
 .top::before,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178544923/comments/225670010

## Motivation
Tooltips should be able to sit on top of all other content. As a result, they should have a high z-index.

The z-index chosen is somewhat arbitrary, but I had to make it high enough to eclipse most modals, popovers, and other rich-content featuring dialog boxes since those can also contain tooltips.


## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-tooltips-above-all/
- [x] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
