### PR TITLE
v0.79.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
-  - fix(tooltip): added a z-index to tooltips so they can generally be on top of everything. Tooltips are legal inside of other "stacking" content and should be on top.
 </details>
+
+## 0.79.1
+  - fix(tooltip): added a z-index to tooltips so they can generally be on top of everything. Tooltips are legal inside of other "stacking" content and should be on top.
 
 ## 0.79.0
 - feat(help-icon): added `classNames` api to provide classes to icon & tooltip

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mavenlink/design-system",
-  "version": "0.79.0",
+  "version": "0.79.1",
   "description": "Mavenlink React Components",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
  - fix(tooltip): added a z-index to tooltips so they can generally be on top of everything. Tooltips are legal inside of other "stacking" content and should be on top.
