### PR TITLE
MDS Select Dropdown Max Height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
+  - fix(Select): add a maximum height to the `<Select />` dropdown equal to 10 rows
 </details>
 
 ## 0.80.0

--- a/src/components/select/select.css
+++ b/src/components/select/select.css
@@ -9,6 +9,8 @@
   composes: container from '../listbox/listbox.css';
   box-sizing: border-box;
   background-color: var(--white);
+  max-height: calc(var(--spacing-x-large) * 10);
+  overflow-y: scroll;
   position: absolute;
   width: 100%;
   z-index: 10;

--- a/src/components/select/select.md
+++ b/src/components/select/select.md
@@ -43,7 +43,7 @@ import ListOption from '../list-option/list-option.jsx';
 import RefExample from '@mavenlink/design-system/src/components/__site__/ref-example/ref-example.jsx';
 
 const ref = React.createRef();
-const listOptions = ['test', 'this', 'select'];
+const listOptions = ['test', 'this', 'select', 'foo', 'bar', 'baz', '1', '2', '3', '4', '5', '6', '7'];
 const listOptionRefs = listOptions.map(() => React.createRef());
 const listOptionElements = listOptions.map((optionName, index) => {
   return(<ListOption key={optionName} ref={listOptionRefs[index]} value={optionName}>{optionName}</ListOption>);


### PR DESCRIPTION
Co-authored-by: Makenzie Larsen <mlarsen@mavenlink.com>
Co-authored-by: Nate Perry <nperry@mavenlink.com>

## Motivation

The MDS Select component can be provided with any number of options as a JSX tree that becomes a child of the dropdown which opens when the user is selecting an option. As a stop-gap to solve the issue of many children before Select gets refactored to provide other ways of circumventing this issue, we want to use a max-height for the dropdown container default styling.

## Acceptance Criteria

The Select component behavior is unchanged, except:
- The dropdown has a maximum height that allows 10 items to be displayed
- The dropdown contents are vertically scrollable if there are more than 10 items

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-how-many-items-do-you-want-to-display-anyways-179017092/
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check
- [x] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
