### PR TITLE
fix(Input): implement `name` ref API on cell controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - feat(Input): implement `className` API
   - feat(Select): implement `className` API
   - feat(Autocompleter): implement `className` API
+  - fix(Input): implement `name` ref API on cell controls
 </details>
 
 ## 0.80.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,24 @@
 
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
-  - refactor(Select): split abstract Select control vs Select form control
-  - feat(Select): implement Select cell control
-  - refactor(Autocompleter): split abstract Autocompleter control vs Autocompleter form control
-  - feat(Autocompleter): implement Autocompleter cell control
-  - feat(IconButton): implement `disabled` API
-  - fix(Form Controls): ensure label use specified MDS fonts
-  - feat(Input): implement `ref` API on input cell controls
-  - feat(Select): implement `ref` API on select cell controls
-  - feat(Autocompleter): implement `ref` API on autocompleter cell controls
-  - feat(CellControl): implement `className` API
-  - feat(Input): implement `className` API
-  - feat(Select): implement `className` API
-  - feat(Autocompleter): implement `className` API
-  - fix(Input): implement `name` ref API on cell controls
-  - fix(FormControl): increase label font sizes to 14px
 </details>
+
+## 0.81.0
+- refactor(Select): split abstract Select control vs Select form control
+- feat(Select): implement Select cell control
+- refactor(Autocompleter): split abstract Autocompleter control vs Autocompleter form control
+- feat(Autocompleter): implement Autocompleter cell control
+- feat(IconButton): implement `disabled` API
+- fix(Form Controls): ensure label use specified MDS fonts
+- feat(Input): implement `ref` API on input cell controls
+- feat(Select): implement `ref` API on select cell controls
+- feat(Autocompleter): implement `ref` API on autocompleter cell controls
+- feat(CellControl): implement `className` API
+- feat(Input): implement `className` API
+- feat(Select): implement `className` API
+- feat(Autocompleter): implement `className` API
+- fix(Input): implement `name` ref API on cell controls
+- fix(FormControl): increase label font sizes to 14px
 
 ## 0.80.1
 - fix(Select): add a maximum height to the `<Select />` dropdown equal to 10 rows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   - feat(Select): implement `className` API
   - feat(Autocompleter): implement `className` API
   - fix(Input): implement `name` ref API on cell controls
+  - fix(FormControl): increase label font sizes to 14px
 </details>
 
 ## 0.80.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mavenlink/design-system",
-  "version": "0.80.0",
+  "version": "0.81.0",
   "description": "Mavenlink React Components",
   "main": "src/index.js",
   "scripts": {

--- a/src/components/cell-control/__snapshots__/input.test.jsx.snap
+++ b/src/components/cell-control/__snapshots__/input.test.jsx.snap
@@ -27,6 +27,7 @@ exports[`Input cell control className API 1`] = `
                 aria-describedby="test-idHint "
                 class="input"
                 id="test-id"
+                name="test-name"
                 type="text"
                 value=""
               />
@@ -114,6 +115,7 @@ exports[`Input cell control id API is a string 1`] = `
                 aria-describedby="unique-idHint "
                 class="input"
                 id="unique-id"
+                name="test-name"
                 type="text"
                 value=""
               />

--- a/src/components/cell-control/__snapshots__/input.test.jsx.snap
+++ b/src/components/cell-control/__snapshots__/input.test.jsx.snap
@@ -66,6 +66,7 @@ exports[`Input cell control has defaults 1`] = `
                 aria-describedby="test-idHint "
                 class="input"
                 id="test-id"
+                name="test-name"
                 type="text"
                 value=""
               />
@@ -81,7 +82,7 @@ exports[`Input cell control has defaults 1`] = `
 exports[`Input cell control has defaults 2`] = `
 Object {
   "dirty": false,
-  "name": undefined,
+  "name": "test-name",
   "value": "",
 }
 `;

--- a/src/components/cell-control/input.jsx
+++ b/src/components/cell-control/input.jsx
@@ -13,6 +13,7 @@ const Input = forwardRef(function Input(props, ref) {
       <InputControl
         id={props.id}
         labelledBy={props.labelledBy}
+        name={props.name}
         readOnly={props.readOnly}
         ref={ref}
         required={props.required}
@@ -29,6 +30,8 @@ Input.propTypes = {
   id: PropTypes.string.isRequired,
   /** The ID of the column header. */
   labelledBy: PropTypes.string.isRequired,
+  /** See documentation on `FormControl#name` */
+  name: PropTypes.string.isRequired,
   /** Disable changes to the input control. */
   readOnly: PropTypes.bool,
   /** Require a value on the input control. */

--- a/src/components/cell-control/input.md
+++ b/src/components/cell-control/input.md
@@ -19,19 +19,19 @@ const ids = {
   <tbody>
     <tr>
       <td role="rowheader">Default</td>
-      <Input labelledBy={ids.th.input} id={uuid.v4()} />
+      <Input labelledBy={ids.th.input} name="input" id={uuid.v4()} />
     </tr>
     <tr>
       <td role="rowheader">Read-only</td>
-      <Input labelledBy={ids.th.input} id={uuid.v4()} readOnly />
+      <Input labelledBy={ids.th.input} name="input" id={uuid.v4()} readOnly />
     </tr>
     <tr>
       <td role="rowheader">Required</td>
-      <Input labelledBy={ids.th.input} id={uuid.v4()} required />
+      <Input labelledBy={ids.th.input} name="input" id={uuid.v4()} required />
     </tr>
     <tr>
       <td role="rowheader">Invalid</td>
-      <Input labelledBy={ids.th.input} id={uuid.v4()} validationMessage="This is an error message!" />
+      <Input labelledBy={ids.th.input} name="input" id={uuid.v4()} validationMessage="This is an error message!" />
     </tr>
   </tbody>
 </table>

--- a/src/components/cell-control/input.test.jsx
+++ b/src/components/cell-control/input.test.jsx
@@ -26,6 +26,7 @@ describe('Input cell control', () => {
   const requiredProps = {
     id: 'test-id',
     labelledBy: 'labelled-by',
+    name: 'test-name',
   };
 
   it('has defaults', () => {
@@ -52,6 +53,13 @@ describe('Input cell control', () => {
     it('is a string', () => {
       render(<Input {...requiredProps} labelledBy="unique-labelledby" />, { labelledBy: 'unique-labelledby' });
       expect(screen.getByRole('gridcell')).toHaveAttribute('aria-labelledby', 'unique-labelledby');
+    });
+  });
+
+  describe('name API', () => {
+    it('is a string', () => {
+      render(<Input {...requiredProps} name="unique-name" />);
+      expect(screen.getByRole('textbox')).toHaveAttribute('name', 'unique-name');
     });
   });
 

--- a/src/components/form-control/form-control.css
+++ b/src/components/form-control/form-control.css
@@ -5,7 +5,7 @@
 .label {
   color: var(--mds-grey-54);
   display: inline-flex;
-  font: var(--mds-type-subtext) !important;
+  font: var(--mds-type-content);
   column-gap: var(--spacing-small);
 }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178801453

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/mds_input_cell_name/
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check https://github.com/mavenlink/mavenlink/pull/25697
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
