### PR TITLE
Minor(ListOption): make text wrap to new line in container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
   - Append new items to make git merging easier.
   - fix(MoneyInput): handle null / undefined so that component is not instantiated with null and instead undefined.
+  - Minor(ListOption): make text wrap to new line in container
 </details>
 
 ## 0.87.0

--- a/src/components/list-option/list-option.css
+++ b/src/components/list-option/list-option.css
@@ -11,13 +11,10 @@
 
   cursor: pointer;
   font: var(--mds-type-content);
-  height: var(--spacing-x-large);
   line-height: var(--spacing-x-large); /* stylelint-disable-line mds/typography */
   list-style-type: none;
   overflow: hidden;
   padding: 0 var(--spacing-medium);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .option:hover {

--- a/src/components/select/select.md
+++ b/src/components/select/select.md
@@ -49,7 +49,7 @@ import ListOption from '../list-option/list-option.jsx';
 import RefExample from '@mavenlink/design-system/src/components/__site__/ref-example/ref-example.jsx';
 
 const ref = React.createRef();
-const listOptions = ['test', 'this', 'select', 'foo', 'bar', 'baz', '1', '2', '3', '4', '5', '6', '7'];
+const listOptions = ['test', 'this', 'select', 'foo', 'bar', 'baz', 'This is a much longer test value that is super long because sometimes people like to put long values in there, you know? It can make sense sometimes. Maybe this is not the best way to convey longform data, but who I am I to say? Power to the people and all that.', '1', '2', '3', '4', '5', '6', '7'];
 const listOptionRefs = listOptions.map(() => React.createRef());
 
 <RefExample ref={ref}>


### PR DESCRIPTION
## Motivation
### Problem
The drop-down menus for custom fields used in a form get truncated and users can't see the full options to choose from.

### Story
As a custom form user, I want to view the entire value associated for each entry in a custom field drop-down menu.

## Acceptance Criteria
- MDS Select (and anywhere that uses ListOption) wraps the label text for options in the dropdown

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-select-dropdown-items-wrapping-179269880/#/Form%20Controls/Select
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
