### PR TITLE
fix(Calendar): set the "year button" type to "button" so we don't submit parent forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 - Append new items to make git merging easier.
 - fix(Calendar): set the "year button" type to "button" so we don't submit parent forms
+- fix(Calendar): after changing the year, moving month stays in the newly selected year
 
 ## 0.88.0
 - fix(MoneyInput): handle null / undefined so that component is not instantiated with null and instead undefined.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 - Append new items to make git merging easier.
+- fix(Calendar): set the "year button" type to "button" so we don't submit parent forms
 
 ## 0.88.0
 - fix(MoneyInput): handle null / undefined so that component is not instantiated with null and instead undefined.

--- a/src/components/calendar/__snapshots__/calendar.test.jsx.snap
+++ b/src/components/calendar/__snapshots__/calendar.test.jsx.snap
@@ -26,6 +26,7 @@ exports[`<Calendar /> has defaults 1`] = `
         </svg>
         <button
           class="year-button"
+          type="button"
         >
           July 2020
           <svg
@@ -567,6 +568,7 @@ exports[`<Calendar /> renders the previous month 1`] = `
         </svg>
         <button
           class="year-button"
+          type="button"
         >
           June 2020
           <svg
@@ -1108,6 +1110,7 @@ exports[`<Calendar /> renders the previous year 1`] = `
         </svg>
         <button
           class="year-button"
+          type="button"
         >
           July 2019
           <svg

--- a/src/components/calendar/calendar.jsx
+++ b/src/components/calendar/calendar.jsx
@@ -202,6 +202,7 @@ function Calendar(props) {
 
   function changeYear(newYear) {
     setYear(newYear.target.current.value.getFullYear());
+    setActiveDate(newYear.target.current.value);
     setYearView(false);
   }
 

--- a/src/components/calendar/calendar.jsx
+++ b/src/components/calendar/calendar.jsx
@@ -305,6 +305,7 @@ function Calendar(props) {
           className={styles['year-button']}
           onClick={onChangeYearView}
           onKeyDown={onYearKeyDown}
+          type="button"
         >
           {currentCalendarMonth.toLocaleDateString(undefined, {
             year: 'numeric',

--- a/src/components/calendar/calendar.test.jsx
+++ b/src/components/calendar/calendar.test.jsx
@@ -97,6 +97,15 @@ describe('<Calendar />', () => {
       userEvent.click(screen.getByText('2022'));
       expect(screen.getByText('July 2022')).toBeInTheDocument();
     });
+
+    it('displays the next month in the correct year after changing the year from the dropdown', () => {
+      render(<Calendar {...requiredProps} />);
+      userEvent.click(screen.getByText('July 2020'));
+      userEvent.click(screen.getByText('2022'));
+
+      userEvent.click(screen.getByTitle('Change calendar to August 2022'));
+      expect(screen.getByText('August 2022')).toBeInTheDocument();
+    });
   });
 
   describe('accessibility', () => {

--- a/src/components/date/__snapshots__/date.test.jsx.snap
+++ b/src/components/date/__snapshots__/date.test.jsx.snap
@@ -149,6 +149,7 @@ exports[`src/components/date/date.test.jsx classNames API sets various class nam
             </svg>
             <button
               class="year-button"
+              type="button"
             >
               April 2021
               <svg


### PR DESCRIPTION
## Motivation
Choosing a year from the year dropdown in the `Calendar` component submits a parent form, and we don't want that.

## Acceptance Criteria
- Button for year selection is not default type "submit"
- Button for year selection is type "button"

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-mds-datepicker-year-dropdown-179583869
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check
- [x] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
