### PR TITLE
Release 0.89.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 - Append new items to make git merging easier.
+
+## 0.89.1
+
 - fix(Calendar): set the "year button" type to "button" so we don't submit parent forms
 - fix(Calendar): after changing the year, moving month stays in the newly selected year
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mavenlink/design-system",
-  "version": "0.89.0",
+  "version": "0.89.1",
   "description": "Mavenlink React Components",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
- fix(Calendar): set the "year button" type to "button" so we don't submit parent forms
- fix(Calendar): after changing the year, moving month stays in the newly selected year
