### PR TITLE
Select- and input-cell value prefills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 - Append new items to make git merging easier.
+- feat(select-cell): allow prefilled values
+- feat(input-cell): allow prefilled values
 
 ## 0.89.1
 

--- a/src/components/cell-control/input.jsx
+++ b/src/components/cell-control/input.jsx
@@ -18,6 +18,7 @@ const Input = forwardRef(function Input(props, ref) {
         ref={ref}
         required={props.required}
         validationMessage={props.validationMessage}
+        value={props.value}
       />
     </CellControl>
   );
@@ -38,6 +39,8 @@ Input.propTypes = {
   required: PropTypes.bool,
   /** A server-side validation message. */
   validationMessage: PropTypes.string,
+  /** The initial value of the cell */
+  value: PropTypes.string,
 };
 
 Input.defaultProps = {
@@ -45,6 +48,7 @@ Input.defaultProps = {
   readOnly: false,
   required: false,
   validationMessage: '',
+  value: '',
 };
 
 export default Input;

--- a/src/components/cell-control/input.test.jsx
+++ b/src/components/cell-control/input.test.jsx
@@ -94,4 +94,11 @@ describe('Input cell control', () => {
       expect(screen.getByRole('textbox')).toHaveDescription('A unique error message.');
     });
   });
+
+  describe('value API', () => {
+    it('can be supplied', () => {
+      render(<Input {...requiredProps} value="Cheese burrito" />);
+      expect(screen.getByRole('textbox')).toHaveValue('Cheese burrito');
+    });
+  });
 });

--- a/src/components/cell-control/select.jsx
+++ b/src/components/cell-control/select.jsx
@@ -24,6 +24,7 @@ const Select = forwardRef(function Select(props, ref) {
         ref={ref}
         required={props.required}
         validationMessage={props.validationMessage}
+        value={props.value}
         wrapperRef={refs.container}
       >
         {props.children}
@@ -49,6 +50,8 @@ Select.propTypes = {
   required: PropTypes.bool,
   /** A server-side validation message. */
   validationMessage: PropTypes.string,
+  /** The initial value of the cell */
+  value: SelectControl.propTypes.value,
 };
 
 Select.defaultProps = {
@@ -57,6 +60,7 @@ Select.defaultProps = {
   readOnly: false,
   required: false,
   validationMessage: '',
+  value: SelectControl.defaultProps.value,
 };
 
 export default Select;

--- a/src/components/cell-control/select.test.jsx
+++ b/src/components/cell-control/select.test.jsx
@@ -1,6 +1,15 @@
 import React, { createRef } from 'react';
-import { render as _render } from '@testing-library/react';
+import { render as _render, screen } from '@testing-library/react';
 import Select from './select.jsx';
+import ListOption from '../list-option/list-option.jsx';
+
+const baseListOptions = ['foo', 'bar'];
+const baseListOptionRefs = baseListOptions.map(() => createRef());
+const baseListOptionElements = ({ onSelect }) => baseListOptions.map((option, index) => (
+  <ListOption key={option} onSelect={onSelect} ref={baseListOptionRefs[index]} value={option}>
+    {option}
+  </ListOption>
+));
 
 const render = (ui, options = { labelledBy: 'labelled-by' }) => (
   _render(ui, {
@@ -41,5 +50,11 @@ describe('Select cell control', () => {
   it('className API', () => {
     render(<Select {...requiredProps} className="unique-class-name" />);
     expect(document.body).toMatchSnapshot();
+  });
+
+  it('accepts a value', () => {
+    const value = 'foo';
+    render(<Select {...requiredProps} value={value}>{baseListOptionElements}</Select>);
+    expect(screen.getByRole('combobox')).toHaveValue('foo');
   });
 });


### PR DESCRIPTION
<!--
In order to reduce overhead in maintaining PRs, please follow these rules:
1. If there is a pivotal story, replace the motivation+AC sections and add the pivotal story URL
2. If there is no pivotal story, fill in the motivation and AC sections
3. Complete the PR checklist
-->


## Motivation
While working on [configuring project participants](https://www.pivotaltracker.com/story/show/179729086) I realized it was not possible to set initial values on some table cells.

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-prefill-table-cells/
- [ ] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
