### PR TITLE
Interactive cells change value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - feat(autocompleter): fetch preloaded value to ensure value is always rendered
 - feat(select-cell): implement onChange API
 - feat(input-cell): implement onChange API
+- fix(autocompleter): ensure value ref API matches prop value API while it is loading
+- fix(select): ensure dynamic prop value does not error during rendering
 
 ## 0.90.0
 - feat(select-cell): allow prefilled values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 - Append new items to make git merging easier.
+- feat(autocompleter): fetch preloaded value to ensure value is always rendered
 - feat(select-cell): implement onChange API
 - feat(input-cell): implement onChange API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 - Append new items to make git merging easier.
+- feat(select-cell): implement onChange API
+- feat(input-cell): implement onChange API
 
 ## 0.90.0
 - feat(select-cell): allow prefilled values

--- a/src/components/autocompleter/autocompleter.test.jsx
+++ b/src/components/autocompleter/autocompleter.test.jsx
@@ -2,6 +2,7 @@ import React, { createRef } from 'react';
 import {
   fireEvent,
   render, screen,
+  waitFor,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import jestServer from '../../mocks/jest-server.js';
@@ -98,12 +99,10 @@ describe('src/components/autocompleter/autocompleter', () => {
 
   describe('value API', () => {
     it('accepts a value', async () => {
-      const value1 = { id: 22, name: 'cool dude' };
-      const value2 = { id: 68, name: 'coolio dude' };
-      const { rerender } = render(<Autocompleter {...requiredProps} value={value1} />);
-      expect(screen.getByLabelText('Test label')).toHaveValue('cool dude');
-      rerender(<Autocompleter {...requiredProps} value={value2} />);
-      expect(screen.getByLabelText('Test label')).toHaveValue('coolio dude');
+      const { rerender } = render(<Autocompleter {...requiredProps} value="731" />);
+      await waitFor(() => expect(screen.getByLabelText('Test label')).toHaveValue('Another page of models!'));
+      rerender(<Autocompleter {...requiredProps} value="732" />);
+      await waitFor(() => expect(screen.getByLabelText('Test label')).toHaveValue('Do not throw the object!'));
     });
   });
 
@@ -128,9 +127,9 @@ describe('src/components/autocompleter/autocompleter', () => {
   describe('forwardRef API', () => {
     it('can be used to get value as array of selected id', async () => {
       const ref = createRef();
-      render(<Autocompleter {...requiredProps} value={{ name: 'neat', id: 11 }} ref={ref} />);
+      render(<Autocompleter {...requiredProps} value={9} ref={ref} />);
 
-      expect(ref.current.value).toStrictEqual({ name: 'neat', id: 11 });
+      await waitFor(() => expect(ref.current.value).toEqual({ id: '9', label: 'Option 9' }));
     });
   });
 
@@ -169,23 +168,22 @@ describe('src/components/autocompleter/autocompleter', () => {
 
     it('is not called when provided a new value prop', () => {
       const onChangeSpy = jest.fn();
-      const { rerender } = render(<Autocompleter {...requiredProps} onChange={onChangeSpy} value={{ id: 22, name: 'hi' }} />);
+      const { rerender } = render(<Autocompleter {...requiredProps} onChange={onChangeSpy} value={9} />);
       expect(onChangeSpy).not.toHaveBeenCalled();
-      rerender(<Autocompleter {...requiredProps} onChange={onChangeSpy} value={{ id: 22, name: 'bye' }} />);
+      rerender(<Autocompleter {...requiredProps} onChange={onChangeSpy} value={8} />);
       expect(onChangeSpy).not.toHaveBeenCalled();
     });
   });
 
   describe('displayValueEvaluator API', () => {
-    it('handles value objects when displayValueEvaluator is provided', () => {
-      const selectValue = { id: 0, label: 'foo' };
+    it('handles value objects when displayValueEvaluator is provided', async () => {
       render(
         <Autocompleter
           {...requiredProps}
-          value={selectValue}
-          displayValueEvaluator={value => value.label}
+          value={55}
+          displayValueEvaluator={value => value.name}
         />);
-      expect(screen.getByLabelText('Test label')).toHaveValue('foo');
+      await waitFor(() => expect(screen.getByLabelText('Test label')).toHaveValue('Foo'));
     });
   });
 

--- a/src/components/autocompleter/autocompleter.test.jsx
+++ b/src/components/autocompleter/autocompleter.test.jsx
@@ -111,7 +111,7 @@ describe('src/components/autocompleter/autocompleter', () => {
       const ref = createRef();
       render(<Autocompleter {...requiredProps} value={9} ref={ref} />);
 
-      await waitFor(() => expect(ref.current.value).toEqual({ id: '9', label: 'Option 9' }));
+      await waitFor(() => expect(ref.current.value).toEqual('9'));
     });
   });
 

--- a/src/components/autocompleter/autocompleter.test.jsx
+++ b/src/components/autocompleter/autocompleter.test.jsx
@@ -106,24 +106,6 @@ describe('src/components/autocompleter/autocompleter', () => {
     });
   });
 
-  describe('models API', () => {
-    it('accepts a an array of models and can re-render', async () => {
-      const models = [{ id: 22, name: 'cool dude' }, { id: 33, name: 'neato burrito' }];
-      const { rerender } = render(<Autocompleter {...requiredProps} models={models} />);
-
-      userEvent.click(screen.getByLabelText('Test label'));
-      expect(screen.getByText('cool dude')).toBeInTheDocument();
-      expect(screen.getByText('neato burrito')).toBeInTheDocument();
-
-      const newModels = [{ id: 44, name: 'wow man' }, { id: 55, name: 'super duper' }];
-      rerender(<Autocompleter {...requiredProps} models={newModels} />);
-
-      userEvent.click(screen.getAllByLabelText('Test label')[1]);
-      expect(screen.getByText('wow man')).toBeInTheDocument();
-      expect(screen.getByText('super duper')).toBeInTheDocument();
-    });
-  });
-
   describe('forwardRef API', () => {
     it('can be used to get value as array of selected id', async () => {
       const ref = createRef();
@@ -145,25 +127,25 @@ describe('src/components/autocompleter/autocompleter', () => {
   });
 
   describe('onChange API', () => {
-    it('calls onChange when a new value is selected', () => {
+    it('calls onChange when a new value is selected', async () => {
       let changeValue = '';
       const onChange = (event) => {
         changeValue = event.target.value;
       };
 
-      const models = [{ id: 22, name: 'Foo' }, { id: 33, name: 'Bar' }];
-      render(<Autocompleter {...requiredProps} models={models} onChange={onChange} />);
+      // const models = [{ id: 22, name: 'Foo' }, { id: 33, name: 'Bar' }];
+      render(<Autocompleter {...requiredProps} onChange={onChange} />);
 
       userEvent.click(screen.getByLabelText('Test label'));
-      userEvent.click(screen.getByText('Foo'));
+      userEvent.click(await screen.findByText('Foo'));
 
-      expect(changeValue).toEqual({ id: 22, name: 'Foo' });
+      expect(changeValue).toEqual({ id: '55', name: 'Foo' });
 
       fireEvent.keyDown(screen.getByRole('button', { name: 'Remove selected choice' }).firstChild, { key: 'Enter', code: 'Enter' });
       userEvent.click(screen.getByLabelText('Test label'));
-      userEvent.click(screen.getByText('Bar'));
+      userEvent.click(await screen.findByText('Bar'));
 
-      expect(changeValue).toEqual({ id: 33, name: 'Bar' });
+      expect(changeValue).toEqual({ id: '1', name: 'Bar' });
     });
 
     it('is not called when provided a new value prop', () => {

--- a/src/components/autocompleter/autocompleter.test.jsx
+++ b/src/components/autocompleter/autocompleter.test.jsx
@@ -133,7 +133,6 @@ describe('src/components/autocompleter/autocompleter', () => {
         changeValue = event.target.value;
       };
 
-      // const models = [{ id: 22, name: 'Foo' }, { id: 33, name: 'Bar' }];
       render(<Autocompleter {...requiredProps} onChange={onChange} />);
 
       userEvent.click(screen.getByLabelText('Test label'));

--- a/src/components/autocompleter/mock-handlers.js
+++ b/src/components/autocompleter/mock-handlers.js
@@ -44,6 +44,14 @@ const models = [
   },
 ];
 
+const onlyModels = [{
+  id: '731',
+  label: 'Another page of models!',
+}, {
+  id: '732',
+  label: 'Do not throw the object!',
+}];
+
 export default function handlers(delay = 0) {
   return [
     rest.get(`${API_ROOT}/models`, (request, response, context) => {
@@ -65,6 +73,10 @@ export default function handlers(delay = 0) {
       const filterStub = request.url.searchParams.get('filter');
       if (filterStub && searchString) {
         modelsForData = [{ name: 'filter-stub', id: '9000' }];
+      }
+
+      if (request.url.searchParams.get('only')) {
+        modelsForData = models.concat(onlyModels).filter(model => model.id === request.url.searchParams.get('only'));
       }
 
       const modelData = {};

--- a/src/components/cell-control/input.jsx
+++ b/src/components/cell-control/input.jsx
@@ -14,6 +14,7 @@ const Input = forwardRef(function Input(props, ref) {
         id={props.id}
         labelledBy={props.labelledBy}
         name={props.name}
+        onChange={props.onChange}
         readOnly={props.readOnly}
         ref={ref}
         required={props.required}
@@ -33,6 +34,7 @@ Input.propTypes = {
   labelledBy: PropTypes.string.isRequired,
   /** See documentation on `FormControl#name` */
   name: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
   /** Disable changes to the input control. */
   readOnly: PropTypes.bool,
   /** Require a value on the input control. */
@@ -45,6 +47,7 @@ Input.propTypes = {
 
 Input.defaultProps = {
   className: undefined,
+  onChange: () => {},
   readOnly: false,
   required: false,
   validationMessage: '',

--- a/src/components/cell-control/input.test.jsx
+++ b/src/components/cell-control/input.test.jsx
@@ -1,5 +1,6 @@
 import React, { createRef } from 'react';
 import { render as _render, screen } from '@testing-library/react';
+import user from '@testing-library/user-event';
 import Input from './input.jsx';
 
 const render = (ui, options = { labelledBy: 'labelled-by' }) => (
@@ -60,6 +61,20 @@ describe('Input cell control', () => {
     it('is a string', () => {
       render(<Input {...requiredProps} name="unique-name" />);
       expect(screen.getByRole('textbox')).toHaveAttribute('name', 'unique-name');
+    });
+  });
+
+  describe('onChange API', () => {
+    it('calls onChange when a new value is selected', () => {
+      const onChange = jest.fn(event => event.persist());
+
+      render(<Input {...requiredProps} onChange={onChange} />);
+
+      user.type(screen.getByRole('textbox'), 'hello world!');
+
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+        target: expect.objectContaining({ value: 'hello world!' }),
+      }));
     });
   });
 

--- a/src/components/cell-control/select.jsx
+++ b/src/components/cell-control/select.jsx
@@ -20,6 +20,7 @@ const Select = forwardRef(function Select(props, ref) {
         labelledBy={props.labelledBy}
         listOptionRefs={props.listOptionRefs}
         name={props.name}
+        onChange={props.onChange}
         readOnly={props.readOnly}
         ref={ref}
         required={props.required}
@@ -44,6 +45,7 @@ Select.propTypes = {
   listOptionRefs: PropTypes.arrayOf(PropTypes.shape({ current: PropTypes.any })).isRequired,
   /** See documentation on `FormControl#name` */
   name: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
   /** Disable changes to the input control. */
   readOnly: PropTypes.bool,
   /** Require a value on the input control. */
@@ -57,6 +59,7 @@ Select.propTypes = {
 Select.defaultProps = {
   children: () => {},
   className: undefined,
+  onChange: () => {},
   readOnly: false,
   required: false,
   validationMessage: '',

--- a/src/components/cell-control/select.test.jsx
+++ b/src/components/cell-control/select.test.jsx
@@ -1,5 +1,6 @@
 import React, { createRef } from 'react';
 import { render as _render, screen } from '@testing-library/react';
+import user from '@testing-library/user-event';
 import Select from './select.jsx';
 import ListOption from '../list-option/list-option.jsx';
 
@@ -56,5 +57,20 @@ describe('Select cell control', () => {
     const value = 'foo';
     render(<Select {...requiredProps} value={value}>{baseListOptionElements}</Select>);
     expect(screen.getByRole('combobox')).toHaveValue('foo');
+  });
+
+  describe('onChange API', () => {
+    it('calls onChange when a new value is selected', () => {
+      const onChange = jest.fn();
+
+      render(<Select {...requiredProps} onChange={onChange}>{baseListOptionElements}</Select>);
+
+      user.click(screen.getByRole('combobox'));
+      user.click(screen.getByText('foo'));
+
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+        target: expect.objectContaining({ value: 'foo' }),
+      }));
+    });
   });
 });

--- a/src/components/control/autocompleter.jsx
+++ b/src/components/control/autocompleter.jsx
@@ -10,14 +10,8 @@ const Autocompleter = forwardRef(function Autocompleter(props, ref) {
   const { execute: executeModels } = useFetch();
   const { execute: executeValue } = useFetch();
   const mounted = useMounted();
-  const [models, setModels] = useState(props.models);
+  const [models, setModels] = useState([]);
   const [model, setModel] = useState();
-
-  useEffect(() => {
-    if (!mounted.current) return;
-
-    setModels(props.models);
-  }, [props.models]);
 
   useEffect(() => {
     fetchModels();
@@ -115,10 +109,6 @@ Autocompleter.propTypes = {
   displayValueEvaluator: PropTypes.func,
   id: PropTypes.string.isRequired,
   labelledBy: PropTypes.string.isRequired,
-  /** `value` and `models` shape is expected to be an object(s) with an `id` key */
-  models: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.string.required,
-  })),
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   onInvalid: PropTypes.func,
@@ -138,7 +128,6 @@ Autocompleter.defaultProps = {
   className: undefined,
   displayValueEvaluator: displayName,
   label: undefined,
-  models: [],
   onChange: () => {},
   onInvalid: () => {},
   placeholder: undefined,

--- a/src/components/control/autocompleter.jsx
+++ b/src/components/control/autocompleter.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { forwardRef, useEffect, useState } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import useFetch from '@bloodyaugust/use-fetch';
 import useMounted from '../../hooks/use-mounted.js';
 import Select from './select.jsx';
@@ -12,6 +12,7 @@ const Autocompleter = forwardRef(function Autocompleter(props, ref) {
   const mounted = useMounted();
   const [models, setModels] = useState([]);
   const [model, setModel] = useState();
+  const selectRef = useRef();
 
   useEffect(() => {
     fetchModels();
@@ -68,6 +69,16 @@ const Autocompleter = forwardRef(function Autocompleter(props, ref) {
 
   const listOptionRefs = models.map(() => React.createRef());
 
+  useImperativeHandle(ref, () => ({
+    ...selectRef.current,
+    get dirty() {
+      return selectRef.current.dirty;
+    },
+    get value() {
+      return selectRef.current.value?.id;
+    },
+  }));
+
   return (
     <Select
       displayValueEvaluator={props.displayValueEvaluator}
@@ -80,7 +91,7 @@ const Autocompleter = forwardRef(function Autocompleter(props, ref) {
       onInvalid={props.onInvalid}
       placeholder={props.placeholder}
       readOnly={props.readOnly}
-      ref={ref}
+      ref={selectRef}
       required={props.required}
       tooltip={props.tooltip}
       validationMessage={props.validationMessage}

--- a/src/components/control/autocompleter.jsx
+++ b/src/components/control/autocompleter.jsx
@@ -11,7 +11,7 @@ const Autocompleter = forwardRef(function Autocompleter(props, ref) {
   const { execute: executeValue } = useFetch();
   const mounted = useMounted();
   const [models, setModels] = useState([]);
-  const [model, setModel] = useState();
+  const [model, setModel] = useState({ id: props.value });
   const selectRef = useRef();
 
   useEffect(() => {

--- a/src/components/control/select.jsx
+++ b/src/components/control/select.jsx
@@ -23,7 +23,7 @@ import useForwardedRef from '../../hooks/use-forwarded-ref.js';
 
 const Select = forwardRef(function Select(props, ref) {
   const [showOptions, setShowOptions] = useState(false);
-  const [value, setValue] = useState(props.value === undefined ? null : props.value);
+  const [value, setValue] = useState(props.value);
   const [hasBeenBlurred, setBeenBlurred] = useState(false);
   const [searchValue, setSearchValue] = useState(undefined);
   const mounted = useMounted();
@@ -59,7 +59,7 @@ const Select = forwardRef(function Select(props, ref) {
   };
 
   const clear = () => {
-    setValue(null);
+    setValue(undefined);
     setSearchValue(undefined);
     refs.input.current.focus();
   };
@@ -121,7 +121,7 @@ const Select = forwardRef(function Select(props, ref) {
     /** The name of the control element which is used to reference the data after submitting the control. */
     name: props.name,
     get value() {
-      return value === null ? undefined : value;
+      return value;
     },
   }));
 

--- a/src/components/control/select.jsx
+++ b/src/components/control/select.jsx
@@ -205,7 +205,7 @@ const Select = forwardRef(function Select(props, ref) {
           required={props.required}
           style={{ '--numIcon': 3 }}
           type="text"
-          value={searchValue ?? defaultValue}
+          value={searchValue ?? defaultValue ?? ''}
         />
         <div className={styles['icon-container']}>
           {validationMessage.length > 0 ? (<Icon

--- a/src/components/control/select.test.jsx
+++ b/src/components/control/select.test.jsx
@@ -35,4 +35,11 @@ describe('src/components/control/select', () => {
     user.click(screen.getByLabelText('Test label'));
     expect(document.body).toMatchSnapshot();
   });
+
+  it('displays (loading) empty objects', () => {
+    const { rerender } = render(<Select {...requiredProps} value={{ id: 8 }} displayValueEvaluator={o => o.label} />);
+    expect(screen.getByLabelText('Test label')).toHaveValue('');
+    rerender(<Select {...requiredProps} value={{ id: 8, label: 'foo' }} displayValueEvaluator={o => o.label} />);
+    expect(screen.getByLabelText('Test label')).toHaveValue('foo');
+  });
 });

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -18,7 +18,7 @@ const CustomFieldInputSingleChoice = forwardRef(function CustomFieldInputSingleC
     },
     get value() {
       const choice = autocompleterRef.current.value;
-      return choice ? [choice.id] : [];
+      return choice ? [choice] : [];
     },
   }));
 

--- a/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
+++ b/src/components/custom-field-input-single-choice/custom-field-input-single-choice.jsx
@@ -1,33 +1,15 @@
 import React, {
   forwardRef,
-  useEffect,
   useImperativeHandle,
   useRef,
-  useState,
 } from 'react';
 import PropTypes from 'prop-types';
-import useFetch from '@bloodyaugust/use-fetch';
 import Autocompleter from '../autocompleter/autocompleter.jsx';
 import useForwardedRef from '../../hooks/use-forwarded-ref.js';
-import { API_ROOT } from '../../mocks/mock-constants.js';
 
 const CustomFieldInputSingleChoice = forwardRef(function CustomFieldInputSingleChoice(props, forwardedRef) {
   const ref = useForwardedRef(forwardedRef);
   const autocompleterRef = useRef();
-  const { execute } = useFetch();
-  const [value, setValue] = useState(undefined);
-
-  useEffect(() => {
-    if (props.value.length) {
-      execute(`${API_ROOT}/custom_field_choices?for_custom_fields=${props.customFieldID}&only=${props.value[0]}`)
-        .then(({ json, mounted }) => {
-          if (!mounted) return;
-          setValue(json.custom_field_choices[json.results[0].id]);
-        });
-    } else {
-      setValue(undefined);
-    }
-  }, [props.value.join(',')]);
 
   useImperativeHandle(ref, () => ({
     ...autocompleterRef.current,
@@ -55,7 +37,7 @@ const CustomFieldInputSingleChoice = forwardRef(function CustomFieldInputSingleC
       required={props.required}
       tooltip={props.tooltip}
       validationMessage={props.errorText}
-      value={value}
+      value={props.value.join(',')}
     />
   );
 });


### PR DESCRIPTION
## Motivation

We need interactive cells! We don't really have usages of our Autocompleter in other parts of the app so I'm taking the liberty to do a breaking change and align the `value` prop with the same shape of data as our backend API (i.e. just an ID).

https://www.pivotaltracker.com/story/show/179729086

## Acceptance Criteria

- Autocompleter still works
- Select still works
- CustomFieldSingleChoice still works

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/interactive-cells-change-value/
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
