### PR TITLE
Webinf custom form builder fields restyling 180076999

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 - Append new items to make git merging easier.
 - fix(use-tooltip-positioning): don't break on `tooltipRef` not containing a `current` value
+- feat(button): add new `subtle` color type
 
 ## 0.92.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 - Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 - Append new items to make git merging easier.
+- fix(use-tooltip-positioning): don't break on `tooltipRef` not containing a `current` value
 
 ## 0.90.0
 - feat(select-cell): allow prefilled values

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -62,3 +62,19 @@
   border: none;
   color: var(--mds-grey-38);
 }
+
+.subtle {
+  composes: button;
+  background-color: transparent;
+  border: none;
+  color: var(--mds-grey-54);
+}
+
+.subtle:hover {
+  background-color: var(--mds-grey-opaque-3);
+  color: var(--mds-grey-87);
+}
+
+.subtle[disabled]:hover {
+  background-color: transparent;
+}

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -25,6 +25,7 @@ Button.propTypes = {
   color: PropTypes.oneOf([
     'primary',
     'secondary',
+    'subtle',
   ]),
   children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,

--- a/src/components/button/button.md
+++ b/src/components/button/button.md
@@ -9,3 +9,7 @@
 ```js
 <Button color="secondary">Secondary Button</Button>
 ```
+
+```js
+<Button color="subtle">Subtle Button</Button>
+```

--- a/src/components/button/button.test.jsx
+++ b/src/components/button/button.test.jsx
@@ -50,6 +50,15 @@ describe('Button', () => {
       ));
       expect(screen.getByText('Hello world!')).toHaveClass('secondary');
     });
+
+    it('can be "subtle"', () => {
+      render((
+        <Button color="subtle">
+          Hello world!
+        </Button>
+      ));
+      expect(screen.getByText('Hello world!')).toHaveClass('subtle');
+    });
   });
 
   describe('disabled API', () => {

--- a/src/components/tooltip/use-tooltip-positioning.js
+++ b/src/components/tooltip/use-tooltip-positioning.js
@@ -12,7 +12,7 @@ export default function useTooltipPositioning({
   const hide = () => setTarget(null);
 
   useLayoutEffect(() => {
-    if (!target) {
+    if (!target || !tooltipRef.current) {
       setPosition(null);
       return;
     }

--- a/src/components/tooltip/use-tooltip-positioning.test.js
+++ b/src/components/tooltip/use-tooltip-positioning.test.js
@@ -29,6 +29,15 @@ describe('use-tooltip-positioning', () => {
     expect(result.current.visible).toBe(false);
   });
 
+  it('does not error if tooltipRef.current is falsy', () => {
+    const target = { getBoundingClientRect: () => ({}) };
+
+    const { result } = renderHook(() => useTooltipPositioning({ ...requiredProps, tooltipRef: { current: null } }));
+    act(() => result.current.show({ target }));
+    act(() => result.current.hide());
+    expect(result.current.visible).toBe(false);
+  });
+
   describe('position and direction', () => {
     const tooltipRect = {
       height: 20,


### PR DESCRIPTION
## Motivation
Fix a bug in `use-tooltip-positioning` and add a new button color type

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-custom-form-builder-fields-restyling-180076999/
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check
- [x] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
