### PR TITLE
Update circleci docker image to the supported image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - run: yarn run wait-on http://localhost:6060 && yarn cypress run
   deploy:
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:14.18
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
CircleCI has deprecated the image we use in this repo. See this [thread](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034/2).

This PR updates to the officially supported image from CircleCI.