### PR TITLE
fix(choice control): only fetch active choices to avoid "duplicates" bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 Prepend new items to make git merging easier.
+
+## 0.99.2
+
 - fix(choice control): only fetch active choices to avoid "duplicates" bug
 
 ## 0.99.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 Prepend new items to make git merging easier.
+- fix(choice control): only fetch active choices to avoid "duplicates" bug
 
 ## 0.99.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mavenlink/design-system",
-  "version": "0.99.1",
+  "version": "0.99.2",
   "description": "Mavenlink React Components",
   "main": "src/index.js",
   "scripts": {

--- a/src/components/cell-control/choice.jsx
+++ b/src/components/cell-control/choice.jsx
@@ -8,7 +8,7 @@ const Choice = forwardRef(function Choice(props, forwardedRef) {
 
   return (
     <Autocompleter
-      apiEndpoint={`/custom_field_choices?for_custom_fields=${props.customFieldID}`}
+      apiEndpoint={`/custom_field_choices?for_custom_fields=${props.customFieldID}&active=true`}
       classNames={props.classNames}
       displayValueEvaluator={selectValue => (selectValue ? selectValue.label : '')}
       id={props.id}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181360714

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/duplicate-choices/
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check https://github.com/mavenlink/mavenlink/pull/28099
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
