### PR TITLE
feat(autocompleter control): Add singleModelParam to Autocompleter control, use for single model fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 Prepend new items to make git merging easier.
+- feat(autocompleter control): Add singleModelParam to Autocompleter control, use for single model fetching
 
 ## 0.99.2
 

--- a/src/components/autocompleter/autocompleter.jsx
+++ b/src/components/autocompleter/autocompleter.jsx
@@ -50,6 +50,7 @@ const Autocompleter = forwardRef(function Autocompleter(props, forwardedRef) {
         ref={refs.input}
         required={props.required}
         searchParam={props.searchParam}
+        singleModelParam={props.singleModelParam}
         validationMessage={props.validationMessage}
         value={props.value}
         wrapperRef={refs.control}
@@ -76,6 +77,7 @@ Autocompleter.propTypes = {
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
   searchParam: PropTypes.string,
+  singleModelParam: PropTypes.string,
   tooltip: PropTypes.string,
   validationMessage: PropTypes.string,
   /** The `value` prop expects an `id` used to fetch a model on the API. */
@@ -93,6 +95,7 @@ Autocompleter.defaultProps = {
   readOnly: false,
   required: false,
   searchParam: 'matching',
+  singleModelParam: 'only',
   tooltip: undefined,
   validationMessage: undefined,
   value: undefined,

--- a/src/components/autocompleter/autocompleter.md
+++ b/src/components/autocompleter/autocompleter.md
@@ -9,7 +9,7 @@ import Autocompleter from './autocompleter.jsx';
 ### Initial value examples
 ```js
 import Autocompleter from './autocompleter.jsx';
-<Autocompleter apiEndpoint='/models' value={11} id={uuid.v4()} name='value-ex' label='Value Example' />
+<Autocompleter apiEndpoint='/models' value={2} id={uuid.v4()} name='value-ex' label='Value Example' />
 ```
 
 ## Ref API Example

--- a/src/components/autocompleter/autocompleter.test.jsx
+++ b/src/components/autocompleter/autocompleter.test.jsx
@@ -198,6 +198,15 @@ describe('src/components/autocompleter/autocompleter', () => {
     });
   });
 
+  describe('singleModelParam API', () => {
+    it('uses the singleModelParam prop when props.value changes', async () => {
+      const { rerender } = render(<Autocompleter {...requiredProps} singleModelParam={'matching'} />);
+      rerender(<Autocompleter {...requiredProps} singleModelParam={'matching'} value={'Fizz'} />);
+
+      await waitFor(() => expect(screen.getByLabelText('Test label')).toHaveValue('Fizz'));
+    });
+  });
+
   describe('tooltip API', () => {
     const tooltip = 'I am an input, short and stout.';
 

--- a/src/components/control/autocompleter.jsx
+++ b/src/components/control/autocompleter.jsx
@@ -20,7 +20,7 @@ const Autocompleter = forwardRef(function Autocompleter(props, ref) {
 
   useEffect(() => {
     if (props.value) {
-      executeValue(apiEndpoint('only', props.value))
+      executeValue(apiEndpoint(props.singleModelParam, props.value))
         .then((respObj) => {
           if (mounted.current) {
             setModel(respObj.json.results.map(result => respObj.json[result.key][result.id])[0]);
@@ -134,6 +134,7 @@ Autocompleter.propTypes = {
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
   searchParam: PropTypes.string,
+  singleModelParam: PropTypes.string,
   tooltip: PropTypes.string,
   validationMessage: PropTypes.string,
   validationMessageTooltip: PropTypes.bool,
@@ -153,6 +154,7 @@ Autocompleter.defaultProps = {
   readOnly: false,
   required: false,
   searchParam: 'matching',
+  singleModelParam: 'only',
   tooltip: undefined,
   validationMessage: undefined,
   validationMessageTooltip: false,


### PR DESCRIPTION
## Motivation
The `Currency` controller in BigMaven (and possibly others) does not use a classic BrainstemPresenter, and does not support the `only` `queryParam`. This means that `Autocompleter`, when provided with `params.value`, does not correctly return only one `Currency`. The correct `queryParam` for that endpoint is `matching`, so we need to support an override here for that. The default value for this param is `only`, to maintain existing functionality without need for code changes.

## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-currency-autocompleter-single-match-180877221/
- [x] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
