### PR TITLE
Webinf multi select valid state bug 180605060

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Prepend new items to make git merging easier.
 - refactor(multi-select): move container styling inside the form control for easier refactoring to a multi-select control
 - refactor(multi-select): move dropdown inside the form control for easier refactoring to a multi-select control
 - fix(choice control): only fetch active choices to avoid "duplicates" bug
+- fix(multi-select): don't set invalid when blurring to click an option from the dropdown
 
 ## 0.99.1
 - fix(analytics): only track the hash to group activity across various domains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 Prepend new items to make git merging easier.
+- fix(multi-select): don't set invalid when blurring to click an option from the dropdown
 
 ## 0.100.0
 
@@ -25,7 +26,6 @@ Prepend new items to make git merging easier.
 ## 0.99.2
 
 - fix(choice control): only fetch active choices to avoid "duplicates" bug
-- fix(multi-select): don't set invalid when blurring to click an option from the dropdown
 
 ## 0.99.1
 - fix(analytics): only track the hash to group activity across various domains

--- a/src/components/control/multi-select.jsx
+++ b/src/components/control/multi-select.jsx
@@ -129,11 +129,17 @@ const MultiSelect = forwardRef(function MultiSelect(props, ref) {
       .filter(option => props.optionLabelGetter(option).toLowerCase().includes(autocompleteValue.toLowerCase()));
   }
 
-  function onAutocompleteBlur() {
+  function onAutocompleteBlur({ relatedTarget }) {
     if (!refs.autocomplete.current) return;
 
     refs.autocomplete.current.setCustomValidity('');
     if (!refs.autocomplete.current.validity.valid) {
+      if (visibleOptionsRefs.find((optionRef) => {
+        return optionRef.current && optionRef.current.rootRef.current === relatedTarget;
+      })) {
+        setValidationMessage(props.validationMessage || '');
+        return;
+      }
       setValidationMessage(refs.autocomplete.current.validationMessage);
     } else {
       setValidationMessage(props.validationMessage || '');

--- a/src/components/control/multi-select.jsx
+++ b/src/components/control/multi-select.jsx
@@ -191,6 +191,12 @@ const MultiSelect = forwardRef(function MultiSelect(props, ref) {
     setExpanded(true);
   }
 
+  function onCaretIconClick() {
+    if (props.readOnly) return;
+
+    setExpanded(true);
+  }
+
   function onKeyDown(event) {
     switch (event.key) {
       case 'Escape':
@@ -297,7 +303,7 @@ const MultiSelect = forwardRef(function MultiSelect(props, ref) {
             disabled={props.readOnly}
             icon={iconCaretDown}
             label="Open options"
-            onPress={onClick}
+            onPress={onCaretIconClick}
           />
         </Icons>
       </div>

--- a/src/components/multi-select/multi-select.test.jsx
+++ b/src/components/multi-select/multi-select.test.jsx
@@ -224,9 +224,11 @@ describe('<MultiSelect>', () => {
       userEvent.click(await findAutocompleter('test label'));
       userEvent.tab();
       expect(await findAutocompleter('test label')).toBeInvalid();
+      expect(screen.getByText('Constraints not satisfied', { selector: 'span' })).toBeInTheDocument();
       userEvent.click(await findAutocompleter('test label'));
       userEvent.click(await findAvailableOption('test label', 'Foo'));
       expect(await findAutocompleter('test label')).toBeValid();
+      expect(screen.queryByText('Constraints not satisfied', { selector: 'span' })).not.toBeInTheDocument();
     });
 
     it('can be set to `false`', async () => {


### PR DESCRIPTION
## Motivation
Don't have the `MultiSelect` be invalid immediately after the first choice is made.


## Acceptance Criteria
- When selecting an option with an empty `MultiSelect`:
  - The invalid state is not triggered


## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/webinf-multi-select-valid-state-bug-180605060/
- [x] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
