### PR TITLE
Revert URL fanciness

### DIFF
--- a/src/components/control/multi-autocompleter.jsx
+++ b/src/components/control/multi-autocompleter.jsx
@@ -4,10 +4,8 @@ import useFetch from '@bloodyaugust/use-fetch';
 import MultiSelect from '../control/multi-select.jsx';
 import { API_ROOT } from '../../mocks/mock-constants.js';
 
-function generateUrl(apiEndpoint, [key, value]) {
-  const url = new URL(`${API_ROOT}${apiEndpoint}`);
-  url.searchParams.append(key, value);
-  return url.toString();
+function generateUrl(apiEndpoint, params) {
+  return `${API_ROOT}${apiEndpoint}${apiEndpoint.includes('?') ? '&' : '?'}${params}`;
 }
 
 const MultiAutocompleter = forwardRef(function MultiAutocompleter(props, ref) {

--- a/src/components/control/multi-autocompleter.jsx
+++ b/src/components/control/multi-autocompleter.jsx
@@ -2,9 +2,10 @@ import PropTypes from 'prop-types';
 import React, { forwardRef, useEffect, useState, useRef } from 'react';
 import useFetch from '@bloodyaugust/use-fetch';
 import MultiSelect from '../control/multi-select.jsx';
+import { API_ROOT } from '../../mocks/mock-constants.js';
 
 function generateUrl(apiEndpoint, [key, value]) {
-  const url = new URL(`api/v1${apiEndpoint}`, `${window.location.protocol}//${window.location.host}`);
+  const url = new URL(`${API_ROOT}${apiEndpoint}`);
   url.searchParams.append(key, value);
   return url.toString();
 }


### PR DESCRIPTION
<!--
In order to reduce overhead in maintaining PRs, please follow these rules:
1. If there is a pivotal story, replace the motivation+AC sections and add the pivotal story URL
2. If there is no pivotal story, fill in the motivation and AC sections
3. Complete the PR checklist
-->


## Motivation

Bigmaven does not work "out of the box" with the new URL. I think we want to sit down and get it working in its own effort.

- Upgrade Jest (et al) dependencies
- Configure Jest with JSDOM with relevant bits (e.g. a set URL)
- Fix broken tests given the aforementioned upgrades

## Acceptance Criteria

Green!

## PR upkeep checklist

- [ ] Change log entry
- [ ] Label(s)
- [ ] Assignee(s)
- [ ] Deployment URL: https://mavenlink.github.io/design-system/$BRANCH/
- [ ] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
