### PR TITLE
Release 0.100.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 Prepend new items to make git merging easier.
+
+## 0.100.3
 - fix(multi-select): don't set invalid when blurring to click an option from the dropdown
 
 ## 0.100.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mavenlink/design-system",
-  "version": "0.100.1",
+  "version": "0.100.3",
   "description": "Mavenlink React Components",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Note: this is technically a re-release of existing functionality, but that functionality had not yet been merged to master. Affected versions are 0.100.1 and 0.100.2.

## 0.100.3
- fix(multi-select): don't set invalid when blurring to click an option from the dropdown


## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [ ] Deployment URL: https://mavenlink.github.io/design-system/$BRANCH/
- [ ] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
