### PR TITLE
fix(MultiSelect): clicking within the component focuses the autocomplete input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 Prepend new items to make git merging easier.
+
+## 0.101.1
+
 - fix(MultiSelect): clicking within the component focuses the autocomplete input
 
 ## 0.101.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 Prepend new items to make git merging easier.
+- fix(MultiSelect): clicking within the component focuses the autocomplete input
 
 ## 0.101.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mavenlink/design-system",
-  "version": "0.101.0",
+  "version": "0.101.1",
   "description": "Mavenlink React Components",
   "main": "src/index.js",
   "scripts": {

--- a/src/components/control/multi-select.jsx
+++ b/src/components/control/multi-select.jsx
@@ -176,6 +176,7 @@ const MultiSelect = forwardRef(function MultiSelect(props, ref) {
 
   function onClick(event) {
     if (event.defaultPrevented) return;
+    if (event.target !== refs.autocomplete.current) refs.autocomplete.current.focus();
     if (props.readOnly) return;
 
     setExpanded(true);


### PR DESCRIPTION
<!--
In order to reduce overhead in maintaining PRs, please follow these rules:
1. If there is a pivotal story, replace the motivation+AC sections and add the pivotal story URL
2. If there is no pivotal story, fill in the motivation and AC sections
3. Complete the PR checklist
-->


## Motivation

QA observed that you can click around the icons and it would not "focus" the component. After clicking away, client-side validations were not running.

## Acceptance Criteria

- On a required multi-select (or variants), you can click around the icons and click away 
- Client-side validations show up as appropriate (e.g. required)

## PR upkeep checklist

- [x] Change log entry
- [x] Deployment URL: https://mavenlink.github.io/design-system/fix-focus-on-multi-autocompleter/
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
