### PR TITLE
- fix(Select): clearing items triggers props.onChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 Prepend new items to make git merging easier.
+- fix(Select): clearing items triggers props.onChange
 
 ## 0.101.1
 

--- a/src/components/control/select.jsx
+++ b/src/components/control/select.jsx
@@ -59,6 +59,7 @@ const Select = forwardRef(function Select(props, ref) {
   };
 
   const clear = () => {
+    props.onChange({ target: { ...selfRef.current, value: undefined } });
     setValue(undefined);
     setSearchValue(undefined);
     refs.input.current.focus();

--- a/src/components/control/select.test.jsx
+++ b/src/components/control/select.test.jsx
@@ -5,6 +5,7 @@ import {
 } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import Select from './select.jsx';
+import ListOption from '../list-option/list-option.jsx';
 
 const render = (ui, options = { labelledBy: 'labelled-by' }) => (
   _render(ui, {
@@ -50,6 +51,24 @@ describe('src/components/control/select', () => {
     expect(screen.getByLabelText('Test label')).toHaveValue('');
     rerender(<Select {...requiredProps} value={{ id: 8, label: 'foo' }} displayValueEvaluator={o => o.label} />);
     expect(screen.getByLabelText('Test label')).toHaveValue('foo');
+  });
+
+  it('calls props.onChange after clear (regression test)', async () => {
+    const onChangeSpy = jest.fn();
+    const listOptions = [{ id: 0, label: 'foo' }];
+    const listOptionRefs = listOptions.map(() => React.createRef());
+    const listOptionElements = ({ onSelect }) => listOptions.map((option, index) => {
+      return (<ListOption key={option.id} onSelect={onSelect} ref={listOptionRefs[index]} value={option}>
+        {option.label}
+      </ListOption>);
+    });
+    render(<Select {...requiredProps} listOptionRefs={listOptionRefs} displayValueEvaluator={o => o.label} onChange={onChangeSpy}>
+      { listOptionElements }
+    </Select>);
+    user.click(screen.getByTitle('Open choices listbox'));
+    user.click(await screen.findByText('foo'));
+    user.click(screen.getByTitle('Remove selected choice'));
+    expect(onChangeSpy).toHaveBeenCalledWith(expect.objectContaining({ target: { dirty: true, name: 'field-id', value: undefined } }));
   });
 
   describe('classNames API', () => {


### PR DESCRIPTION
<!--
In order to reduce overhead in maintaining PRs, please follow these rules:
1. If there is a pivotal story, replace the motivation+AC sections and add the pivotal story URL
2. If there is no pivotal story, fill in the motivation and AC sections
3. Complete the PR checklist
-->


## Motivation
There was a minor bug where clearing a value wouldn't trigger onChange. This is because we do this check in the useEffect; `if (JSON.stringify(props.value) === JSON.stringify(value)) return;`.

## Acceptance Criteria


## PR upkeep checklist

- [x] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [ ] Deployment URL: https://mavenlink.github.io/design-system/$BRANCH/
- [ ] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
