### PR TITLE
[Api] Add onFocus and onBlur to control cell inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ Major/Minor/Patch: This is an example changelog item, usually can be the commit 
 Prepend new items to make git merging easier.
 -fix(Number): add id and name into ref. Ensure onChange value on ref is a number
 -fix(Date): add id and name into ref
+- feat(Date): Add ability to pass `onFocus` and `onBlur` into cell control
+- feat(Autocompleter): Add ability to pass `onFocus` and `onBlur` into cell control
+- feat(Input): Add ability to pass `onFocus` and `onBlur` into cell control
+- feat(Money): Add ability to pass `onFocus` and `onBlur` into cell control
+- feat(MultiAutocompleter): Add ability to pass `onFocus` and `onBlur` into cell control
+- feat(MultiSelect): Add ability to pass `onFocus` and `onBlur` into cell control
+- feat(Number): Add ability to pass `onFocus` and `onBlur` into cell control
+- feat(Select): Add ability to pass `onFocus` and `onBlur` into cell control
 
 ## 0.101.5
 

--- a/src/components/cell-control/autocompleter.jsx
+++ b/src/components/cell-control/autocompleter.jsx
@@ -33,7 +33,9 @@ const Autocompleter = forwardRef(function Autocompleter(props, ref) {
         labelledBy={props.labelledBy}
         models={props.models}
         name={props.name}
+        onBlur={props.onBlur}
         onChange={props.onChange}
+        onFocus={props.onFocus}
         placeholder={props.placeholder}
         readOnly={props.readOnly}
         ref={ref}
@@ -65,7 +67,9 @@ Autocompleter.propTypes = {
     id: PropTypes.string.required,
   })),
   name: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
@@ -80,7 +84,9 @@ Autocompleter.defaultProps = {
   classNames: {},
   displayValueEvaluator: undefined,
   models: [],
+  onBlur: () => {},
   onChange: () => {},
+  onFocus: () => {},
   placeholder: undefined,
   readOnly: false,
   required: false,

--- a/src/components/cell-control/date.jsx
+++ b/src/components/cell-control/date.jsx
@@ -29,7 +29,9 @@ const Date = forwardRef(function Date(props, ref) {
         labelledBy={props.labelledBy}
         max={props.max}
         min={props.min}
+        onBlur={props.onBlur}
         onChange={props.onChange}
+        onFocus={props.onFocus}
         placeholder={props.placeholder}
         readOnly={props.readOnly}
         required={props.required}
@@ -55,7 +57,9 @@ Date.propTypes = {
   max: PropTypes.string,
   /** The earliest date to accept in full-date format (i.e. yyyy-mm-dd) */
   min: PropTypes.string,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
@@ -68,7 +72,9 @@ Date.defaultProps = {
   classNames: {},
   max: undefined,
   min: undefined,
+  onBlur: () => {},
   onChange: undefined,
+  onFocus: () => {},
   placeholder: undefined,
   readOnly: false,
   required: false,

--- a/src/components/cell-control/input.jsx
+++ b/src/components/cell-control/input.jsx
@@ -18,7 +18,9 @@ const Input = forwardRef(function Input(props, ref) {
         }}
         id={props.id}
         name={props.name}
+        onBlur={props.onBlur}
         onChange={props.onChange}
+        onFocus={props.onFocus}
         readOnly={props.readOnly}
         ref={ref}
         required={props.required}
@@ -38,7 +40,9 @@ Input.propTypes = {
   labelledBy: PropTypes.string.isRequired,
   /** See documentation on `FormControl#name` */
   name: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   /** Disable changes to the input control. */
   readOnly: PropTypes.bool,
   /** Require a value on the input control. */
@@ -51,7 +55,9 @@ Input.propTypes = {
 
 Input.defaultProps = {
   className: styles.container,
+  onBlur: () => {},
   onChange: () => {},
+  onFocus: () => {},
   readOnly: false,
   required: false,
   validationMessage: '',

--- a/src/components/cell-control/input.test.jsx
+++ b/src/components/cell-control/input.test.jsx
@@ -78,6 +78,35 @@ describe('Input cell control', () => {
     });
   });
 
+  describe('onFocus API', () => {
+    it('calls onChange when a new value is selected', () => {
+      const onFocus = jest.fn(event => event.persist());
+
+      render(<Input {...requiredProps} onFocus={onFocus} />);
+
+      user.click(screen.getByRole('textbox'));
+
+      expect(onFocus).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'focus',
+      }));
+    });
+  });
+
+  describe('onBlur API', () => {
+    it('calls onChange when a new value is selected', () => {
+      const onBlur = jest.fn(event => event.persist());
+
+      render(<Input {...requiredProps} onBlur={onBlur} />);
+
+      user.click(screen.getByRole('textbox'));
+      user.tab();
+
+      expect(onBlur).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'blur',
+      }));
+    });
+  });
+
   describe('readOnly API', () => {
     it('is true', () => {
       render(<Input {...requiredProps} readOnly={true} />);

--- a/src/components/cell-control/money.jsx
+++ b/src/components/cell-control/money.jsx
@@ -22,7 +22,9 @@ const Money = forwardRef(function Money(props, ref) {
         className={classNames.input}
         currencyCode={props.currencyCode}
         id={props.id}
+        onBlur={props.onBlur}
         onChange={props.onChange}
+        onFocus={props.onFocus}
         placeholder={props.placeholder}
         readOnly={props.readOnly}
         required={props.required}
@@ -47,7 +49,9 @@ Money.propTypes = {
    * The handler is invoked for every native onchange event.
    * The handler will be invoked with the forwarded ref.
    */
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
@@ -59,7 +63,9 @@ Money.defaultProps = {
   classNames: {},
   currencyCode: 'USD',
   errorText: undefined,
+  onBlur: () => {},
   onChange: () => {},
+  onFocus: () => {},
   placeholder: undefined,
   readOnly: false,
   required: false,

--- a/src/components/cell-control/multi-autocompleter.jsx
+++ b/src/components/cell-control/multi-autocompleter.jsx
@@ -35,7 +35,9 @@ const MultiAutocompleter = forwardRef(function MultiAutocompleter(props, ref) {
         containerRef={refs.control}
         filterOptions={false}
         id={props.id}
+        onBlur={props.onBlur}
         onChange={props.onChange}
+        onFocus={props.onFocus}
         optionIDGetter={props.optionIDGetter}
         optionLabelGetter={props.optionLabelGetter}
         placeholder={props.placeholder}
@@ -57,7 +59,9 @@ MultiAutocompleter.propTypes = {
   classNames: PropTypes.shape({}),
   id: PropTypes.string.isRequired,
   labelledBy: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   optionIDGetter: PropTypes.func,
   optionLabelGetter: PropTypes.func,
   placeholder: PropTypes.string,
@@ -72,7 +76,9 @@ MultiAutocompleter.propTypes = {
 
 MultiAutocompleter.defaultProps = {
   classNames: {},
+  onBlur: () => {},
   onChange: () => {},
+  onFocus: () => {},
   optionIDGetter: option => option.id,
   optionLabelGetter: option => option.title || option.name || option.full_name || option.currency || option.label,
   placeholder: undefined,

--- a/src/components/cell-control/multi-select.jsx
+++ b/src/components/cell-control/multi-select.jsx
@@ -35,7 +35,9 @@ const MultiSelect = forwardRef(function MultiSelect(props, ref) {
         filterOptions={props.filterOptions}
         id={props.id}
         listboxChildren={props.listboxChildren}
+        onBlur={props.onBlur}
         onChange={props.onChange}
+        onFocus={props.onFocus}
         onInput={props.onInput}
         options={props.options}
         optionIDGetter={props.optionIDGetter}
@@ -62,7 +64,9 @@ MultiSelect.propTypes = {
   id: PropTypes.string.isRequired,
   labelledBy: PropTypes.string.isRequired,
   listboxChildren: PropTypes.func, // eslint-disable-line react/no-unused-prop-types
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   onInput: PropTypes.func,
   options: PropTypes.arrayOf(PropTypes.object).isRequired,
   /** the default getters reflect a native `select` element with `option` element children:
@@ -83,7 +87,9 @@ MultiSelect.defaultProps = {
   classNames: {},
   filterOptions: true,
   listboxChildren: undefined,
+  onBlur: () => {},
   onChange: () => {},
+  onFocus: () => {},
   onInput: () => {},
   optionIDGetter: option => option.value,
   optionLabelGetter: option => option.label,

--- a/src/components/cell-control/number.jsx
+++ b/src/components/cell-control/number.jsx
@@ -21,7 +21,8 @@ const Number = React.forwardRef((props, ref) => {
         id={props.id}
         onChange={props.onChange}
         placeholder={props.placeholder}
-        onFocus={() => props.onEnterCell()}
+        onFocus={event => props.onEnterCell(event.target.value)}
+        onBlur={event => props.onExitCell(event.target.value)}
         readOnly={props.readOnly}
         ref={ref}
         required={props.required}
@@ -47,6 +48,7 @@ Number.propTypes = {
    */
   onChange: PropTypes.func,
   onEnterCell: PropTypes.func,
+  onExitCell: PropTypes.func,
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
@@ -59,6 +61,7 @@ Number.defaultProps = {
   classNames: {},
   onChange: () => {},
   onEnterCell: () => {},
+  onExitCell: () => {},
   placeholder: undefined,
   readOnly: false,
   required: false,

--- a/src/components/cell-control/number.jsx
+++ b/src/components/cell-control/number.jsx
@@ -21,6 +21,7 @@ const Number = React.forwardRef((props, ref) => {
         id={props.id}
         onChange={props.onChange}
         placeholder={props.placeholder}
+        onFocus={() => props.onEnterCell()}
         readOnly={props.readOnly}
         ref={ref}
         required={props.required}
@@ -45,6 +46,7 @@ Number.propTypes = {
    * an empty string when the input is invalid.
    */
   onChange: PropTypes.func,
+  onEnterCell: PropTypes.func,
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
@@ -56,6 +58,7 @@ Number.propTypes = {
 Number.defaultProps = {
   classNames: {},
   onChange: () => {},
+  onEnterCell: () => {},
   placeholder: undefined,
   readOnly: false,
   required: false,

--- a/src/components/cell-control/number.jsx
+++ b/src/components/cell-control/number.jsx
@@ -19,10 +19,10 @@ const Number = React.forwardRef((props, ref) => {
       <NumberControl
         className={classNames.input}
         id={props.id}
+        onBlur={props.onBlur}
         onChange={props.onChange}
+        onFocus={props.onFocus}
         placeholder={props.placeholder}
-        onFocus={event => props.onEnterCell(event.target.value)}
-        onBlur={event => props.onExitCell(event.target.value)}
         readOnly={props.readOnly}
         ref={ref}
         required={props.required}
@@ -46,9 +46,9 @@ Number.propTypes = {
    * **Beware:** According to the HTML spec, the `event.target.value` is
    * an empty string when the input is invalid.
    */
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
-  onEnterCell: PropTypes.func,
-  onExitCell: PropTypes.func,
+  onFocus: PropTypes.func,
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
@@ -59,9 +59,9 @@ Number.propTypes = {
 
 Number.defaultProps = {
   classNames: {},
+  onBlur: () => {},
   onChange: () => {},
-  onEnterCell: () => {},
-  onExitCell: () => {},
+  onFocus: () => {},
   placeholder: undefined,
   readOnly: false,
   required: false,

--- a/src/components/cell-control/number.test.jsx
+++ b/src/components/cell-control/number.test.jsx
@@ -1,5 +1,6 @@
 import React, { createRef } from 'react';
-import { render as _render } from '@testing-library/react';
+import { render as _render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Number from './number.jsx';
 
 const render = (ui, options = { labelledBy: 'labelled-by' }) => (
@@ -34,5 +35,14 @@ describe('Number cell control', () => {
     expect(document.body).toMatchSnapshot();
     expect(document.body).toBe(document.activeElement);
     expect(ref.current).toMatchSnapshot();
+  });
+
+  it('alerts when user enters the cell', () => {
+    const onEnterCell = jest.fn();
+    render(<Number onChange={() => {}} value={1} {...requiredProps} onEnterCell={onEnterCell} />);
+
+    userEvent.click(within(screen.queryByLabelText('Column Header')).getByDisplayValue('1'));
+
+    expect(onEnterCell).toHaveBeenCalledWith();
   });
 });

--- a/src/components/cell-control/number.test.jsx
+++ b/src/components/cell-control/number.test.jsx
@@ -37,12 +37,22 @@ describe('Number cell control', () => {
     expect(ref.current).toMatchSnapshot();
   });
 
-  it('alerts when user enters the cell', () => {
+  it('alerts when user focuses into the cell', () => {
     const onEnterCell = jest.fn();
     render(<Number onChange={() => {}} value={1} {...requiredProps} onEnterCell={onEnterCell} />);
 
     userEvent.click(within(screen.queryByLabelText('Column Header')).getByDisplayValue('1'));
 
-    expect(onEnterCell).toHaveBeenCalledWith();
+    expect(onEnterCell).toHaveBeenCalledWith('1');
+  });
+
+  it('alerts when user moves focus out of the cell', () => {
+    const onExitCell = jest.fn();
+    render(<Number onChange={() => {}} value={1} {...requiredProps} onExitCell={onExitCell} />);
+
+    userEvent.click(within(screen.queryByLabelText('Column Header')).getByDisplayValue('1'));
+    userEvent.tab();
+
+    expect(onExitCell).toHaveBeenCalledWith('1');
   });
 });

--- a/src/components/cell-control/number.test.jsx
+++ b/src/components/cell-control/number.test.jsx
@@ -38,21 +38,21 @@ describe('Number cell control', () => {
   });
 
   it('alerts when user focuses into the cell', () => {
-    const onEnterCell = jest.fn();
-    render(<Number onChange={() => {}} value={1} {...requiredProps} onEnterCell={onEnterCell} />);
+    const onFocus = jest.fn(event => event.persist());
+    render(<Number onChange={() => {}} value={1} {...requiredProps} onFocus={onFocus} />);
 
     userEvent.click(within(screen.queryByLabelText('Column Header')).getByDisplayValue('1'));
 
-    expect(onEnterCell).toHaveBeenCalledWith('1');
+    expect(onFocus).toHaveBeenCalledWith(expect.objectContaining({ type: 'focus' }));
   });
 
   it('alerts when user moves focus out of the cell', () => {
-    const onExitCell = jest.fn();
-    render(<Number onChange={() => {}} value={1} {...requiredProps} onExitCell={onExitCell} />);
+    const onBlur = jest.fn(event => event.persist());
+    render(<Number onChange={() => {}} value={1} {...requiredProps} onBlur={onBlur} />);
 
     userEvent.click(within(screen.queryByLabelText('Column Header')).getByDisplayValue('1'));
     userEvent.tab();
 
-    expect(onExitCell).toHaveBeenCalledWith('1');
+    expect(onBlur).toHaveBeenCalledWith(expect.objectContaining({ type: 'blur' }));
   });
 });

--- a/src/components/cell-control/select.jsx
+++ b/src/components/cell-control/select.jsx
@@ -25,7 +25,9 @@ const Select = forwardRef(function Select(props, ref) {
         labelledBy={props.labelledBy}
         listOptionRefs={props.listOptionRefs}
         name={props.name}
+        onBlur={props.onBlur}
         onChange={props.onChange}
+        onFocus={props.onFocus}
         readOnly={props.readOnly}
         ref={ref}
         required={props.required}
@@ -50,7 +52,9 @@ Select.propTypes = {
   listOptionRefs: PropTypes.arrayOf(PropTypes.shape({ current: PropTypes.any })).isRequired,
   /** See documentation on `FormControl#name` */
   name: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   /** Disable changes to the input control. */
   readOnly: PropTypes.bool,
   /** Require a value on the input control. */
@@ -64,7 +68,9 @@ Select.propTypes = {
 Select.defaultProps = {
   children: () => {},
   className: undefined,
+  onBlur: () => {},
   onChange: () => {},
+  onFocus: () => {},
   readOnly: false,
   required: false,
   validationMessage: '',

--- a/src/components/cell-control/select.md
+++ b/src/components/cell-control/select.md
@@ -41,8 +41,6 @@ const options = [
         labelledBy={ids.th.example}
         listOptionRefs={options[0].map(option => option.ref)}
         name="select-1"
-        onFocus={e => console.log('focus', e)}
-        onBlur={e => console.log('blur', e)}
       >
         {({ onSelect }) => options[0].map((option, index) => (
           <ListOption key={option.id} onSelect={onSelect} ref={option.ref} value={option.label}>

--- a/src/components/cell-control/select.md
+++ b/src/components/cell-control/select.md
@@ -41,6 +41,8 @@ const options = [
         labelledBy={ids.th.example}
         listOptionRefs={options[0].map(option => option.ref)}
         name="select-1"
+        onFocus={e => console.log('focus', e)}
+        onBlur={e => console.log('blur', e)}
       >
         {({ onSelect }) => options[0].map((option, index) => (
           <ListOption key={option.id} onSelect={onSelect} ref={option.ref} value={option.label}>

--- a/src/components/cell-control/textarea.jsx
+++ b/src/components/cell-control/textarea.jsx
@@ -23,9 +23,10 @@ const Textarea = forwardRef(function Textarea(props, ref) {
     ...props.classNames,
   };
 
-  function onBlur() {
+  function onBlur(event) {
     validate();
     setHeight(undefined);
+    props.onBlur(event);
   }
 
   function onChange(event) {
@@ -33,8 +34,9 @@ const Textarea = forwardRef(function Textarea(props, ref) {
     props.onChange(event);
   }
 
-  function onFocus() {
+  function onFocus(event) {
     setHeight(refs.textarea.current.scrollHeight);
+    props.onFocus(event);
   }
 
   useImperativeHandle(ref, () => {
@@ -79,7 +81,9 @@ Textarea.propTypes = {
   /* The ID of the header cell. */
   labelledBy: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
@@ -91,7 +95,9 @@ Textarea.defaultProps = {
   classNames: {},
   readOnly: false,
   required: false,
+  onBlur: () => {},
   onChange: () => {},
+  onFocus: () => {},
   placeholder: '',
   validationMessage: '',
   value: '',

--- a/src/components/cell-control/textarea.test.jsx
+++ b/src/components/cell-control/textarea.test.jsx
@@ -130,4 +130,31 @@ describe('Textarea cell control', () => {
       expect(ref.current.value).toBe('Unique value');
     });
   });
+
+  describe('onFocus API', () => {
+    it('calls onFocus', () => {
+      const onFocus = jest.fn(event => event.persist());
+      render(<Textarea {...requiredProps} onFocus={onFocus} />);
+      const textbox = screen.getByRole('textbox');
+      user.click(textbox);
+      expect(onFocus).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'focus',
+        target: textbox,
+      }));
+    });
+  });
+
+  describe('onBlur API', () => {
+    it('calls onBlur', () => {
+      const onBlur = jest.fn(event => event.persist());
+      render(<Textarea {...requiredProps} onBlur={onBlur} />);
+      const textbox = screen.getByRole('textbox');
+      user.click(textbox);
+      user.tab();
+      expect(onBlur).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'blur',
+        target: textbox,
+      }));
+    });
+  });
 });

--- a/src/components/control/autocompleter.jsx
+++ b/src/components/control/autocompleter.jsx
@@ -87,7 +87,9 @@ const Autocompleter = forwardRef(function Autocompleter(props, ref) {
       labelledBy={props.labelledBy}
       listOptionRefs={listOptionRefs}
       name={props.name}
+      onBlur={props.onBlur}
       onChange={props.onChange}
+      onFocus={props.onFocus}
       onInput={onInput}
       onInvalid={props.onInvalid}
       placeholder={props.placeholder}
@@ -127,7 +129,9 @@ Autocompleter.propTypes = {
   id: PropTypes.string.isRequired,
   labelledBy: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   onInvalid: PropTypes.func,
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
@@ -145,7 +149,9 @@ Autocompleter.defaultProps = {
   classNames: {},
   displayValueEvaluator: displayName,
   label: undefined,
+  onBlur: () => {},
   onChange: () => {},
+  onFocus: () => {},
   onInvalid: () => {},
   placeholder: undefined,
   readOnly: false,

--- a/src/components/control/date.jsx
+++ b/src/components/control/date.jsx
@@ -88,9 +88,7 @@ const Date = forwardRef(function Date(props, forwardedRef) {
   function onInputClick(event) {
     if (props.readOnly) return;
     event.preventDefault();
-    if (!active) {
-      refs.input.current.focus();
-    }
+    if (!active) refs.input.current.focus();
     setExpanded(true);
   }
 

--- a/src/components/control/date.jsx
+++ b/src/components/control/date.jsx
@@ -79,8 +79,9 @@ const Date = forwardRef(function Date(props, forwardedRef) {
     setValue(fromFullDateFormat(refs.input.current.value));
   }
 
-  function onFocusIntoDateControl() {
+  function onFocusIntoDateControl(event) {
     if (props.readOnly) return;
+    if (!active) props.onFocus(event);
     setActive(true);
     setEditing(true);
   }

--- a/src/components/control/date.jsx
+++ b/src/components/control/date.jsx
@@ -88,8 +88,9 @@ const Date = forwardRef(function Date(props, forwardedRef) {
   function onInputClick(event) {
     if (props.readOnly) return;
     event.preventDefault();
-    setActive(true);
-    setEditing(true);
+    if (!active) {
+      refs.input.current.focus();
+    }
     setExpanded(true);
   }
 
@@ -237,6 +238,7 @@ Date.propTypes = {
   onActivate: PropTypes.func,
   onChange: PropTypes.func,
   onDeactivate: PropTypes.func,
+  onFocus: PropTypes.func,
   onInvalid: PropTypes.func,
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
@@ -254,6 +256,7 @@ Date.defaultProps = {
   onActivate: () => {},
   onChange: undefined,
   onDeactivate: () => {},
+  onFocus: () => {},
   onInvalid: () => {},
   placeholder: undefined,
   readOnly: false,

--- a/src/components/control/date.jsx
+++ b/src/components/control/date.jsx
@@ -72,6 +72,7 @@ const Date = forwardRef(function Date(props, forwardedRef) {
 
     validate();
     setActive(false);
+    props.onBlur(event);
     if (!props.validationMessage) setEditing(false);
   }
 

--- a/src/components/control/date.jsx
+++ b/src/components/control/date.jsx
@@ -33,18 +33,9 @@ function fromFullDateFormat(string) {
   return date;
 }
 
-function usePrevious(value) {
-  const ref = useRef();
-  React.useEffect(() => {
-    ref.current = value;
-  });
-  return ref.current;
-}
-
 const Date = forwardRef(function Date(props, forwardedRef) {
   const ref = useForwardedRef(forwardedRef);
   const [active, setActive] = useState(false);
-  const previousActive = usePrevious(active);
   const [editing, setEditing] = useState(!!props.validationMessage);
   const [expanded, setExpanded] = useState(false);
   const [value, setValue] = useState(fromFullDateFormat(props.value));
@@ -134,15 +125,6 @@ const Date = forwardRef(function Date(props, forwardedRef) {
   useEffect(() => {
     if (active && props.onChange) props.onChange({ target: ref.current });
   }, [value]);
-
-  useEffect(() => {
-    if (!previousActive && active) {
-      props.onActivate(value);
-    }
-    if (previousActive && !active) {
-      props.onDeactivate(value);
-    }
-  });
 
   useLayoutEffect(() => {
     if (active) refs.input.current.focus();
@@ -235,9 +217,8 @@ Date.propTypes = {
   /** The earliest date to accept in full-date format (i.e. yyyy-mm-dd) */
   min: PropTypes.string,
   name: PropTypes.string,
-  onActivate: PropTypes.func,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
-  onDeactivate: PropTypes.func,
   onFocus: PropTypes.func,
   onInvalid: PropTypes.func,
   placeholder: PropTypes.string,
@@ -253,9 +234,8 @@ Date.defaultProps = {
   max: undefined,
   min: undefined,
   name: undefined,
-  onActivate: () => {},
+  onBlur: () => {},
   onChange: undefined,
-  onDeactivate: () => {},
   onFocus: () => {},
   onInvalid: () => {},
   placeholder: undefined,

--- a/src/components/control/date.test.jsx
+++ b/src/components/control/date.test.jsx
@@ -5,7 +5,7 @@ import Date from './date.jsx';
 
 describe('<Date />', () => {
   describe('onFocus API', () => {
-    it('calls onFocus ctive when user clicks on date control', () => {
+    it('calls onFocus when user clicks on date control', () => {
       const onFocus = jest.fn(event => event.persist());
       render(<>
         <Date id="test-id" onFocus={onFocus} />

--- a/src/components/control/date.test.jsx
+++ b/src/components/control/date.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, screen,} from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import Date from './date.jsx';
 

--- a/src/components/control/date.test.jsx
+++ b/src/components/control/date.test.jsx
@@ -5,7 +5,7 @@ import Date from './date.jsx';
 
 describe('<Date />', () => {
   describe('onFocus API', () => {
-    it('toggles date to active when user clicks on date control', () => {
+    it('calls onFocus ctive when user clicks on date control', () => {
       const onFocus = jest.fn(event => event.persist());
       render(<>
         <Date id="test-id" onFocus={onFocus} />
@@ -34,7 +34,7 @@ describe('<Date />', () => {
       }));
     });
 
-    it('deactivate when user tabs out of the Input', () => {
+    it('blur when user tabs out of the Input', () => {
       const onBlur = jest.fn(event => event.persist());
       render(<>
         <button aria-label="pre input button" />

--- a/src/components/control/date.test.jsx
+++ b/src/components/control/date.test.jsx
@@ -7,42 +7,18 @@ import user from '@testing-library/user-event';
 import Date from './date.jsx';
 
 describe('<Date />', () => {
-  describe('onActivate API', () => {
+  describe('onFocus API', () => {
     it('toggles date to active when user clicks on date control', () => {
-      const onActivate = jest.fn();
+      const onFocus = jest.fn(event => event.persist());
       render(<>
-        <Date id="test-id" onActivate={onActivate} />
+        <Date id="test-id" onFocus={onFocus} />
       </>);
 
-      user.click(screen.getByRole('textbox'));
-      expect(onActivate).toHaveBeenCalledWith(undefined);
-    });
-
-    it('toggles date and sends value at time when user clicks on date control', () => {
-      const onActivate = jest.fn();
-      render(<>
-        <Date id="test-id" value="2022-01-01" onActivate={onActivate} />
-      </>);
-
-      user.click(screen.getByRole('textbox'));
-      expect(onActivate).toHaveBeenCalledWith(new window.Date('2022-01-01T00:00:00'));
-    });
-
-    it('activates the date cell when user tabs back into the Input', () => {
-      const onActivate = jest.fn();
-      render(<>
-        <button aria-label="pre input button" />
-        <Date id="test-id" value="2022-01-01" onActivate={onActivate} />
-        <button aria-label="post input button" />
-      </>);
-
-      // User has Focused on Element Before Date Input
-      user.click(screen.getByRole('button', { name: 'post input button' }));
-
-      // User Tabs to the Date Input
-      user.tab({ shift: true });
-      expect(screen.getByDisplayValue('2022-01-01')).toHaveFocus();
-      expect(onActivate).toHaveBeenCalled();
+      const input = screen.getByRole('textbox');
+      user.click(input);
+      expect(onFocus).toHaveBeenCalledWith(expect.objectContaining({
+        target: input,
+      }));
     });
   });
 

--- a/src/components/control/date.test.jsx
+++ b/src/components/control/date.test.jsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import {
-  render,
-  screen,
-} from '@testing-library/react';
+import {render, screen,} from '@testing-library/react';
 import user from '@testing-library/user-event';
 import Date from './date.jsx';
 
@@ -22,24 +19,26 @@ describe('<Date />', () => {
     });
   });
 
-  describe('onDeactivate API', () => {
+  describe('onBlur API', () => {
     it('toggles active when user clicks away from the date control', () => {
-      const onDeactivate = jest.fn();
+      const onBlur = jest.fn(event => event.persist());
       render(<>
-        <Date id="test-id" onDeactivate={onDeactivate} />
+        <Date id="test-id" onBlur={onBlur} />
         <button aria-label="click away button" />
       </>);
 
       user.click(screen.getByRole('textbox'));
       user.click(screen.getByLabelText('click away button'));
-      expect(onDeactivate).toHaveBeenCalledWith(undefined);
+      expect(onBlur).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'blur',
+      }));
     });
 
     it('deactivate when user tabs out of the Input', () => {
-      const onDeactivate = jest.fn();
+      const onBlur = jest.fn(event => event.persist());
       render(<>
         <button aria-label="pre input button" />
-        <Date id="test-id" value="2022-01-01" onDeactivate={onDeactivate} />
+        <Date id="test-id" value="2022-01-01" onBlur={onBlur} />
         <button aria-label="click away button" />
       </>);
 
@@ -48,18 +47,20 @@ describe('<Date />', () => {
 
       // User Tabs to the Date Input
       user.tab();
-      expect(onDeactivate).not.toHaveBeenCalled();
+      expect(onBlur).not.toHaveBeenCalled();
       expect(screen.getByDisplayValue('2022-01-01')).toHaveFocus();
 
       // User Tabs to the Calendar Button (Still Part of the Date Input)
       user.tab();
-      expect(onDeactivate).not.toHaveBeenCalled();
+      expect(onBlur).not.toHaveBeenCalled();
       expect(screen.getByRole('button', { name: 'calendar button' })).toHaveFocus();
 
       // User Tabs to button outside of calendar input
       user.tab();
       expect(screen.getByRole('button', { name: 'click away button' })).toHaveFocus();
-      expect(onDeactivate).toHaveBeenCalledWith(new window.Date('2022-01-01'));
+      expect(onBlur).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'blur',
+      }));
     });
   });
 });

--- a/src/components/control/money.jsx
+++ b/src/components/control/money.jsx
@@ -22,12 +22,13 @@ const Money = forwardRef(function Money(props, ref) {
       setIsEditing(false);
     }
 
+    props.onBlur(event);
     setIsFocused(false);
   }
 
-  function handleOnFocus() {
+  function handleOnFocus(event) {
     if (props.readOnly) return;
-
+    props.onFocus(event);
     setIsEditing(true);
     setIsFocused(true);
   }
@@ -140,7 +141,9 @@ Money.propTypes = {
    * The handler is invoked for every native onchange event.
    * The handler will be invoked with the forwarded ref.
    */
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   onInvalid: PropTypes.func,
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
@@ -155,8 +158,10 @@ Money.defaultProps = {
   describedBy: '',
   errorText: undefined,
   name: undefined,
+  onBlur: () => {},
   onChange: () => {},
   onInvalid: () => {},
+  onFocus: () => {},
   placeholder: undefined,
   readOnly: false,
   required: false,

--- a/src/components/control/multi-autocompleter.jsx
+++ b/src/components/control/multi-autocompleter.jsx
@@ -118,6 +118,8 @@ const MultiAutocompleter = forwardRef(function MultiAutocompleter(props, forward
       name={props.name}
       onChange={onMultiSelectChange}
       onInput={onMultiSelectInput}
+      onFocus={props.onFocus}
+      onBlur={props.onBlur}
       onInvalid={props.onInvalid}
       optionIDGetter={props.optionIDGetter}
       optionLabelGetter={props.optionLabelGetter}
@@ -142,7 +144,9 @@ MultiAutocompleter.propTypes = {
   containerRef: PropTypes.any.isRequired,
   id: PropTypes.string.isRequired,
   name: PropTypes.string,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   onInvalid: PropTypes.func,
   optionIDGetter: PropTypes.func,
   optionLabelGetter: PropTypes.func,
@@ -162,7 +166,9 @@ MultiAutocompleter.propTypes = {
 MultiAutocompleter.defaultProps = {
   classNames: {},
   name: undefined,
+  onBlur: () => {},
   onChange: () => {},
+  onFocus: () => {},
   onInvalid: () => {},
   optionIDGetter: (option) => { return option?.id || option; },
   optionLabelGetter: option => option.title || option.name || option.full_name || option.currency || option.label,

--- a/src/components/control/multi-select.jsx
+++ b/src/components/control/multi-select.jsx
@@ -133,7 +133,13 @@ const MultiSelect = forwardRef(function MultiSelect(props, ref) {
   function onBlur(event) {
     if (!refs.autocomplete.current) return;
     if (refs.root.current.contains(event.relatedTarget)) return;
+    props.onBlur(event);
     validate();
+  }
+
+  function onFocus(event) {
+    if (refs.root.current.contains(event.relatedTarget)) return;
+    props.onFocus(event);
   }
 
   function onAutocompleteChange(event) {
@@ -224,6 +230,7 @@ const MultiSelect = forwardRef(function MultiSelect(props, ref) {
   return (
     <div
       onBlur={onBlur}
+      onFocus={onFocus}
       ref={refs.root}
       style={{ height: '100%' }}
     >
@@ -311,7 +318,9 @@ MultiSelect.propTypes = {
   filterOptions: PropTypes.bool,
   id: PropTypes.string.isRequired,
   listboxChildren: PropTypes.func, // eslint-disable-line react/no-unused-prop-types
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   onInput: PropTypes.func,
   onInvalid: PropTypes.func,
   options: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -333,7 +342,9 @@ MultiSelect.defaultProps = {
   classNames: {},
   filterOptions: true,
   listboxChildren: undefined,
+  onBlur: () => {},
   onChange: () => {},
+  onFocus: () => {},
   onInput: () => {},
   onInvalid: () => {},
   optionIDGetter: option => option.value,

--- a/src/components/control/number.jsx
+++ b/src/components/control/number.jsx
@@ -89,6 +89,7 @@ const Number = React.forwardRef((props, forwardedRef) => {
         name={props.name}
         onBlur={onBlur}
         onChange={() => { props.onChange({ target: ref.current }); }}
+        onFocus={props.onFocus}
         placeholder={props.placeholder}
         ref={refs.input}
         readOnly={props.readOnly}
@@ -116,6 +117,7 @@ Number.propTypes = {
    * an empty string when the input is invalid.
    */
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   onInvalid: PropTypes.func,
   placeholder: PropTypes.string,
   readOnly: PropTypes.bool,
@@ -130,6 +132,7 @@ Number.defaultProps = {
   name: undefined,
   onBlur: () => {},
   onChange: () => {},
+  onFocus: () => {},
   onInvalid: () => {},
   placeholder: undefined,
   readOnly: false,

--- a/src/components/control/select.jsx
+++ b/src/components/control/select.jsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import PropTypes, {func} from 'prop-types';
+import PropTypes, { func } from 'prop-types';
 import Icons from './icons.jsx';
 import IconButton from '../icon-button/icon-button.jsx';
 import iconClear from '../../svgs/clear.svg';
@@ -36,6 +36,7 @@ const Select = forwardRef(function Select(props, ref) {
   useDropdownClose(wrapperRef, showOptions, handleDropdownClose);
 
   const refs = {
+    container: useRef(),
     listbox: useRef(),
     input: useRef(),
   };
@@ -65,7 +66,7 @@ const Select = forwardRef(function Select(props, ref) {
     refs.input.current.focus();
   };
 
-  function onBlur(event) {
+  function onBlurInput(event) {
     if (!(refs.listbox.current && refs.listbox.current.contains(event.relatedTarget))) {
       validate();
     }
@@ -73,7 +74,14 @@ const Select = forwardRef(function Select(props, ref) {
     setBeenBlurred(true);
   }
 
+  function onBlur(event) {
+    if (refs.container.current.contains(event.relatedTarget)) return;
+    if (props.readOnly) return;
+    props.onBlur(event);
+  }
+
   function onFocus(event) {
+    if (refs.container.current.contains(event.relatedTarget)) return;
     if (props.readOnly) return;
     if (showOptions) return;
     props.onFocus(event);
@@ -189,9 +197,11 @@ const Select = forwardRef(function Select(props, ref) {
 
   return (
     <div
+      ref={refs.container}
       className={classNames.container}
       style={{ height: '100%', position: 'relative' }}
       onFocus={onFocus}
+      onBlur={onBlur}
     >
       <input
         autoComplete="off"
@@ -205,7 +215,7 @@ const Select = forwardRef(function Select(props, ref) {
         id={ids.input}
         role="combobox"
         name={props.name}
-        onBlur={onBlur}
+        onBlur={onBlurInput}
         onChange={onSearchChange}
         onClick={onClick}
         onKeyDown={onKeyDown}

--- a/src/components/control/select.jsx
+++ b/src/components/control/select.jsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import PropTypes, { func } from 'prop-types';
+import PropTypes from 'prop-types';
 import Icons from './icons.jsx';
 import IconButton from '../icon-button/icon-button.jsx';
 import iconClear from '../../svgs/clear.svg';

--- a/src/components/control/select.jsx
+++ b/src/components/control/select.jsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import PropTypes from 'prop-types';
+import PropTypes, {func} from 'prop-types';
 import Icons from './icons.jsx';
 import IconButton from '../icon-button/icon-button.jsx';
 import iconClear from '../../svgs/clear.svg';
@@ -71,6 +71,12 @@ const Select = forwardRef(function Select(props, ref) {
     }
 
     setBeenBlurred(true);
+  }
+
+  function onFocus(event) {
+    if (props.readOnly) return;
+    if (showOptions) return;
+    props.onFocus(event);
   }
 
   function onClick() {
@@ -182,7 +188,11 @@ const Select = forwardRef(function Select(props, ref) {
   }, [value, showOptions]);
 
   return (
-    <div className={classNames.container} style={{ height: '100%', position: 'relative' }}>
+    <div
+      className={classNames.container}
+      style={{ height: '100%', position: 'relative' }}
+      onFocus={onFocus}
+    >
       <input
         autoComplete="off"
         aria-autocomplete="none"
@@ -271,7 +281,9 @@ Select.propTypes = {
   labelledBy: PropTypes.string.isRequired,
   listOptionRefs: PropTypes.arrayOf(ListOptionRefType).isRequired,
   name: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   onInput: PropTypes.func,
   onInvalid: PropTypes.func,
   placeholder: PropTypes.string,
@@ -287,7 +299,9 @@ Select.defaultProps = {
   children: () => {},
   classNames: {},
   displayValueEvaluator: value => value,
+  onBlur: () => {},
   onChange: () => {},
+  onFocus: () => {},
   onInput: () => {},
   onInvalid: () => {},
   placeholder: undefined,

--- a/src/components/control/select.test.jsx
+++ b/src/components/control/select.test.jsx
@@ -71,6 +71,32 @@ describe('src/components/control/select', () => {
     expect(onChangeSpy).toHaveBeenCalledWith(expect.objectContaining({ target: { dirty: true, name: 'field-id', value: undefined } }));
   });
 
+  describe('onFocus API', () => {
+    it('focuses on the Select', async () => {
+      const onFocus = jest.fn(event => event.persist());
+      const listOptions = [{ id: 0, label: 'foo' }];
+      const listOptionRefs = listOptions.map(() => React.createRef());
+      const listOptionElements = ({ onSelect }) => listOptions.map((option, index) => {
+        return (<ListOption key={option.id} onSelect={onSelect} ref={listOptionRefs[index]} value={option}>
+          {option.label}
+        </ListOption>);
+      });
+      render(<Select {...requiredProps} listOptionRefs={listOptionRefs} displayValueEvaluator={o => o.label} onFocus={onFocus}>
+        { listOptionElements }
+      </Select>);
+
+      const focusTarget = screen.getByRole('combobox');
+
+      user.click(screen.getByRole('combobox'));
+      user.click(await screen.findByText('foo'));
+
+      expect(onFocus).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'focus',
+        target: focusTarget,
+      }));
+    });
+  });
+
   describe('classNames API', () => {
     it('sets container', () => {
       render(<Select

--- a/src/components/control/select.test.jsx
+++ b/src/components/control/select.test.jsx
@@ -97,6 +97,32 @@ describe('src/components/control/select', () => {
     });
   });
 
+  describe('onBlur API', () => {
+    it('focuses on the Select', async () => {
+      const onBlur = jest.fn(event => event.persist());
+      const listOptions = [{ id: 0, label: 'foo' }];
+      const listOptionRefs = listOptions.map(() => React.createRef());
+      const listOptionElements = ({ onSelect }) => listOptions.map((option, index) => {
+        return (<ListOption key={option.id} onSelect={onSelect} ref={listOptionRefs[index]} value={option}>
+          {option.label}
+        </ListOption>);
+      });
+      render(<Select {...requiredProps} listOptionRefs={listOptionRefs} displayValueEvaluator={o => o.label} onBlur={onBlur}>
+        { listOptionElements }
+      </Select>);
+
+      user.click(screen.getByRole('combobox'));
+      user.click(await screen.findByText('foo'));
+      user.tab(); // Tabs to SVG `X` Button
+      user.tab(); // Tabs to SVG `V` Button
+      user.tab(); // Tabs to Body
+
+      expect(onBlur).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'blur',
+      }));
+    });
+  });
+
   describe('classNames API', () => {
     it('sets container', () => {
       render(<Select

--- a/src/components/control/select.test.jsx
+++ b/src/components/control/select.test.jsx
@@ -114,7 +114,9 @@ describe('src/components/control/select', () => {
       user.click(screen.getByRole('combobox'));
       user.click(await screen.findByText('foo'));
       user.tab(); // Tabs to SVG `X` Button
+      expect(onBlur).not.toHaveBeenCalled();
       user.tab(); // Tabs to SVG `V` Button
+      expect(onBlur).not.toHaveBeenCalled();
       user.tab(); // Tabs to Body
 
       expect(onBlur).toHaveBeenCalledWith(expect.objectContaining({

--- a/src/components/multi-autocompleter/multi-autocompleter.jsx
+++ b/src/components/multi-autocompleter/multi-autocompleter.jsx
@@ -45,7 +45,9 @@ const MultiAutocompleter = forwardRef(function MultiAutocompleter(props, ref) {
         id={props.id}
         label={props.label}
         name={props.name}
+        onBlur={props.onBlur}
         onChange={props.onChange}
+        onFocus={props.onFocus}
         onInvalid={onInvalid}
         optionIDGetter={props.optionIDGetter}
         optionLabelGetter={props.optionLabelGetter}
@@ -69,7 +71,9 @@ MultiAutocompleter.propTypes = {
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   optionIDGetter: PropTypes.func,
   optionLabelGetter: PropTypes.func,
   placeholder: PropTypes.string,
@@ -87,7 +91,9 @@ MultiAutocompleter.propTypes = {
 
 MultiAutocompleter.defaultProps = {
   className: undefined,
+  onBlur: () => {},
   onChange: () => {},
+  onFocus: () => {},
   optionIDGetter: (option) => { return option?.id || option; },
   optionLabelGetter: option => option.title || option.name || option.full_name || option.currency || option.label,
   placeholder: undefined,

--- a/src/components/multi-autocompleter/multi-autocompleter.test.jsx
+++ b/src/components/multi-autocompleter/multi-autocompleter.test.jsx
@@ -18,7 +18,6 @@ import {
 import jestServer from '../../mocks/jest-server.js';
 import { API_ROOT } from '../../mocks/mock-constants.js';
 import mockHandlers from '../autocompleter/mock-handlers.js';
-import Date from "../control/date";
 
 describe('<MultiAutocompleter>', () => {
   const requiredProps = {

--- a/src/components/multi-autocompleter/multi-autocompleter.test.jsx
+++ b/src/components/multi-autocompleter/multi-autocompleter.test.jsx
@@ -18,6 +18,7 @@ import {
 import jestServer from '../../mocks/jest-server.js';
 import { API_ROOT } from '../../mocks/mock-constants.js';
 import mockHandlers from '../autocompleter/mock-handlers.js';
+import Date from "../control/date";
 
 describe('<MultiAutocompleter>', () => {
   const requiredProps = {
@@ -300,6 +301,33 @@ describe('<MultiAutocompleter>', () => {
       userEvent.hover(screen.getByRole('img', { name: 'More information' }));
       userEvent.unhover(screen.getByRole('img', { name: 'More information' }));
       expect(screen.getByRole('combobox', { name: requiredProps.label })).toHaveAccessibleDescription('');
+    });
+  });
+
+  describe('onFocus API', () => {
+    it('triggers callback when tooltip is focused', () => {
+      const onFocus = jest.fn(event => event.persist());
+      render(<MultiAutocompleter {...requiredProps} onFocus={onFocus} />);
+
+      userEvent.click(screen.queryByRole('combobox'));
+      expect(onFocus).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'focus',
+      }));
+    });
+  });
+
+  describe('onBlur API', () => {
+    it('triggers callback when tooltip is focused', () => {
+      const onBlur = jest.fn(event => event.persist());
+      render(<MultiAutocompleter {...requiredProps} onBlur={onBlur} />);
+
+      userEvent.click(screen.queryByRole('combobox'));
+      userEvent.tab(); // Clear Button `X`
+      userEvent.tab(); // Expend Button `V`
+      userEvent.tab(); // Document Body
+      expect(onBlur).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'blur',
+      }));
     });
   });
 });

--- a/src/components/multi-select/multi-select.jsx
+++ b/src/components/multi-select/multi-select.jsx
@@ -54,7 +54,9 @@ const MultiSelect = forwardRef(function MultiSelect(props, ref) {
         id={props.id}
         label={props.label}
         listboxChildren={props.listboxChildren}
+        onFocus={props.onFocus}
         onChange={props.onChange}
+        onBlur={props.onBlur}
         onInput={props.onInput}
         onInvalid={onInvalid}
         options={props.options}
@@ -85,7 +87,9 @@ MultiSelect.propTypes = {
   label: PropTypes.string.isRequired,
   listboxChildren: PropTypes.func, // eslint-disable-line react/no-unused-prop-types
   name: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
   onInput: PropTypes.func,
   options: PropTypes.arrayOf(PropTypes.object).isRequired,
   /** the default getters reflect a native `select` element with `option` element children:
@@ -107,7 +111,9 @@ MultiSelect.defaultProps = {
   classNames: {},
   filterOptions: true,
   listboxChildren: undefined,
+  onBlur: () => {},
   onChange: () => {},
+  onFocus: () => {},
   onInput: () => {},
   optionIDGetter: option => option.value,
   optionLabelGetter: option => option.label,

--- a/src/components/multi-select/multi-select.test.jsx
+++ b/src/components/multi-select/multi-select.test.jsx
@@ -579,6 +579,11 @@ describe('<MultiSelect>', () => {
       const multiSelect = screen.getByRole('combobox');
 
       userEvent.click(multiSelect);
+      userEvent.tab(); // The Clear `X` button
+      expect(onBlur).not.toHaveBeenCalled();
+      userEvent.tab(); // The Open Selection `V` button
+      expect(onBlur).not.toHaveBeenCalled();
+      userEvent.tab(); // Document Body
       expect(onBlur).toHaveBeenCalledWith(expect.objectContaining({
         type: 'blur',
       }));

--- a/src/components/multi-select/multi-select.test.jsx
+++ b/src/components/multi-select/multi-select.test.jsx
@@ -557,4 +557,31 @@ describe('<MultiSelect>', () => {
       expect(screen.getByRole('combobox', { name: requiredProps.label })).toHaveAccessibleDescription('');
     });
   });
+
+  describe('onFocus API', () => {
+    it('forwards the native onFocus event', () => {
+      const onFocus = jest.fn(event => event.persist());
+      render(<MultiSelect {...requiredProps} onFocus={onFocus} />);
+      const multiSelect = screen.getByRole('combobox');
+
+      userEvent.click(multiSelect);
+      expect(onFocus).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'focus',
+        target: multiSelect,
+      }));
+    });
+  });
+
+  describe('onBlur API', () => {
+    it('forwards the native onBlur event', () => {
+      const onBlur = jest.fn(event => event.persist());
+      render(<MultiSelect {...requiredProps} onBlur={onBlur} />);
+      const multiSelect = screen.getByRole('combobox');
+
+      userEvent.click(multiSelect);
+      expect(onBlur).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'blur',
+      }));
+    });
+  });
 });


### PR DESCRIPTION
<!--
In order to reduce overhead in maintaining PRs, please follow these rules:
1. If there is a pivotal story, replace the motivation+AC sections and add the pivotal story URL
2. If there is no pivotal story, fill in the motivation and AC sections
3. Complete the PR checklist
-->


## Motivation

Users of the MDS Components should know when the user focuses and blur the control cells


## Acceptance Criteria

Update Cell Control Components to Forward onFocus and onBlur to their children
- [x] Autocompleter
- [x] Date
- [x] Input
- [x] Money
- [x] Multi-Autocompleter
- [x] Multi-Select
- [x] Number
- [x] Select
- [x] Textarea


Mavenlink URL: https://github.com/mavenlink/mavenlink/pull/29320

## PR upkeep checklist

- [ ] Change log entry
- [ ] Label(s)
- [ ] Assignee(s)
- [ ] Deployment URL: https://mavenlink.github.io/design-system/$BRANCH/
- [ ] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
