### PR TITLE
Remove legacy Mavenlink colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mavenlink/design-system",
-  "version": "0.103.0",
+  "version": "0.104.0",
   "description": "Mavenlink React Components",
   "main": "src/index.js",
   "scripts": {

--- a/src/styles/colors-v2.css
+++ b/src/styles/colors-v2.css
@@ -43,18 +43,6 @@
   --mds-kantata-meteorite: #4a3f72;
   --mds-kantata-carbon: #2e2d2c;
   --mds-kantata-bronze: #ae8d58;
-  --mds-kantata-graphite: #333130;
-  --mds-kantata-grape: #26294c;
-  --mds-kantata-royale: #5454e8;
-  --mds-kantata-marine: #4a9cce;
-  --mds-kantata-salmon: #fb806b;
-  --mds-kantata-tangerine: #f7b657;
-  --mds-kantata-sand: #eae0d4;
-  --mds-kantata-slate: #224959;
-  --mds-kantata-rust: #6b2826;
-  --mds-kantata-gold: #cc7a00;
-  --mds-kantata-mint: #29cc9a;
-  --mds-kantata-hot-pink: #d20d59;
 
   /* Red colors */
   --mds-red-text: #b5200f;


### PR DESCRIPTION
<!--
In order to reduce overhead in maintaining PRs, please follow these rules:
1. If there is a pivotal story, replace the motivation+AC sections and add the pivotal story URL
2. If there is no pivotal story, fill in the motivation and AC sections
3. Complete the PR checklist
-->


## Motivation
As per Clarke, these colors are legacy Mavenlink (not Kantata), so we should remove them from the MDS so they are not used.

## Acceptance Criteria


## PR upkeep checklist

- [ ] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [ ] Deployment URL: https://mavenlink.github.io/design-system/$BRANCH/
- [ ] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
