### PR TITLE
make tooltip accessible by keyboard navigation

### DIFF
--- a/src/components/cell-control/__snapshots__/select.test.jsx.snap
+++ b/src/components/cell-control/__snapshots__/select.test.jsx.snap
@@ -184,6 +184,7 @@ exports[`Select cell control validationMessage API shows a tooltip on the invali
               >
                 <div
                   class="wrapper"
+                  tabindex="0"
                 >
                   <svg
                     height="18"

--- a/src/components/help-icon/__snapshots__/help-icon.test.jsx.snap
+++ b/src/components/help-icon/__snapshots__/help-icon.test.jsx.snap
@@ -36,6 +36,7 @@ exports[`HelpIcon direction api allows bottom 1`] = `
   <div>
     <div
       class="wrapper"
+      tabindex="0"
     >
       <svg
         height="18"
@@ -71,6 +72,7 @@ exports[`HelpIcon direction api allows left 1`] = `
   <div>
     <div
       class="wrapper"
+      tabindex="0"
     >
       <svg
         height="18"
@@ -106,6 +108,7 @@ exports[`HelpIcon direction api allows right 1`] = `
   <div>
     <div
       class="wrapper"
+      tabindex="0"
     >
       <svg
         height="18"
@@ -141,6 +144,7 @@ exports[`HelpIcon direction api allows top 1`] = `
   <div>
     <div
       class="wrapper"
+      tabindex="0"
     >
       <svg
         height="18"
@@ -176,6 +180,7 @@ exports[`HelpIcon has defaults 1`] = `
   <div>
     <div
       class="wrapper"
+      tabindex="0"
     >
       <svg
         height="18"
@@ -204,6 +209,7 @@ exports[`HelpIcon has defaults 2`] = `
   <div>
     <div
       class="wrapper"
+      tabindex="0"
     >
       <svg
         height="18"

--- a/src/components/tooltip/__snapshots__/tooltip.test.jsx.snap
+++ b/src/components/tooltip/__snapshots__/tooltip.test.jsx.snap
@@ -55,6 +55,7 @@ exports[`tooltip has defaults 1`] = `
   <div>
     <div
       class="wrapper"
+      tabindex="0"
     >
       <div
         aria-describedby="my-component-tooltip"
@@ -72,6 +73,7 @@ exports[`tooltip has defaults 2`] = `
   <div>
     <div
       class="wrapper"
+      tabindex="0"
     >
       <div
         aria-describedby="my-component-tooltip"

--- a/src/components/tooltip/tooltip.jsx
+++ b/src/components/tooltip/tooltip.jsx
@@ -89,6 +89,6 @@ Tooltip.defaultProps = {
   className: undefined,
   direction: 'top',
   disabled: false,
-  tabIndex: "0",
+  tabIndex: '0',
   variant: 'default',
 };

--- a/src/components/tooltip/tooltip.jsx
+++ b/src/components/tooltip/tooltip.jsx
@@ -13,6 +13,7 @@ export default function Tooltip({
   direction,
   disabled,
   id,
+  tabIndex,
   text,
   variant,
 }) {
@@ -43,6 +44,7 @@ export default function Tooltip({
   return (
     <div
       className={styles.wrapper}
+      tabIndex={tabIndex}
       onBlur={hide}
       onFocus={show}
       onMouseEnter={show}
@@ -76,6 +78,7 @@ Tooltip.propTypes = {
   disabled: PropTypes.bool,
   /** The id that the tooltip should be given. The element that this tooltip is describing <strong>MUST</strong> have <code>aria-describedby={id}</code>. */
   id: PropTypes.string.isRequired,
+  tabIndex: PropTypes.string.isRequired,
   /** The text and/or graphic inside of the tooltip. Tooltip text should be concise and kept to 1-2 short sentences. */
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   /** Show the default dark background tooltip or the light background tooltip */
@@ -86,5 +89,6 @@ Tooltip.defaultProps = {
   className: undefined,
   direction: 'top',
   disabled: false,
+  tabIndex: "0",
   variant: 'default',
 };

--- a/src/components/tooltip/tooltip.test.jsx
+++ b/src/components/tooltip/tooltip.test.jsx
@@ -47,12 +47,14 @@ describe('tooltip', () => {
     it('applies a description to the children when focused', () => {
       render(<Tooltip {...requiredProps}>{children}</Tooltip>);
       user.tab();
+      user.tab();
       expect(screen.getByRole('textbox')).toHaveFocus();
       expect(screen.getByRole('textbox')).toHaveAccessibleDescription('Help Text');
     });
 
     it('removes the description when the child is no longer focused', () => {
       render(<Tooltip {...requiredProps}>{children}</Tooltip>);
+      user.tab();
       user.tab();
       expect(screen.getByRole('textbox')).toHaveFocus();
       expect(screen.getByRole('textbox')).toHaveAccessibleDescription('Help Text');


### PR DESCRIPTION
Co-authored-by: Claire Bendersky <cdersky@gmail.com>

## Motivation
Allow users to view tooltip when navigating our app with a keyboard

## Acceptance Criteria
The tooltip appears and is focusable via keyboard navigation

## PR upkeep checklist

- [ ] Change log entry
- [x] Label(s)
- [x] Assignee(s)
- [ ] Deployment URL: https://mavenlink.github.io/design-system/tab-in-tooltip/
- [x] (When ready for review) Reviewer(s)
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
