### PR TITLE
fix(date): ensure value API returns an ISO8601 format without any timezone offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 Prepend new items to make git merging easier.
 
+## 0.104.1
+
+- fix(Date): value API does not offset by timezone
+
 ## 0.101.7
 
 - feat(Date): Add ability to pass `onFocus` and `onBlur` into cell control

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mavenlink/design-system",
-  "version": "0.104.0",
+  "version": "0.104.1",
   "description": "Mavenlink React Components",
   "main": "src/index.js",
   "scripts": {

--- a/src/components/control/date.jsx
+++ b/src/components/control/date.jsx
@@ -21,7 +21,9 @@ function toDateStringFormat(date) {
 }
 
 function toFullDateFormat(date) {
-  return date ? date.toISOString().slice(0, 10) : undefined;
+  // Note: This returns the localized date without any timezone offset (backend is timezone agnostic).
+  // Note: This uses Sweden as locale because it is one of the countries that uses ISO 8601 format.
+  return date ? date.toLocaleDateString('sv') : undefined;
 }
 
 function fromFullDateFormat(string) {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/182525308

## PR upkeep checklist

- [x] Label(s)
- [x] Assignee(s)
- [x] Deployment URL: https://mavenlink.github.io/design-system/date-fix-value-api/
- [x] (When ready for review) Reviewer(s)
- [x] Green Bigmaven CI check https://github.com/mavenlink/mavenlink/pull/29962
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
