### PR TITLE
feat(Popover): implement className api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 ## Unreleased
 Major/Minor/Patch: This is an example changelog item, usually can be the commit message.
 Prepend new items to make git merging easier.
+- feat(Popover): implement ariaLabel api
+- feat(Popover): implement className api
+- feat(Popover): implement hideHeading api
 
 ## 0.101.6
 
--fix(Number): add id and name into ref. Ensure onChange value on ref is a number
--fix(Date): add id and name into ref
+- fix(Number): add id and name into ref. Ensure onChange value on ref is a number
+- fix(Date): add id and name into ref
 - feat(Date): Add ability to pass `onFocus` and `onBlur` into cell control
 - feat(Autocompleter): Add ability to pass `onFocus` and `onBlur` into cell control
 - feat(Input): Add ability to pass `onFocus` and `onBlur` into cell control

--- a/src/components/popover/popover.jsx
+++ b/src/components/popover/popover.jsx
@@ -28,7 +28,7 @@ const Popover = forwardRef(function Popover(props, ref) {
 
   useLayoutEffect(() => {
     if (open) {
-      closeIconRef.current.focus({ preventScroll: true });
+      closeIconRef.current?.focus({ preventScroll: true });
     }
   }, [open]);
 
@@ -53,25 +53,29 @@ const Popover = forwardRef(function Popover(props, ref) {
 
   return (
     <section
-      aria-labelledby="popover-heading"
-      className={styles.container}
+      aria-labelledby={props.hideHeading ? undefined : 'popover-heading'}
+      className={props.className || styles.container}
       onBlur={onBlur}
       ref={sectionRef}
       role="dialog"
       style={flush}
       tabIndex={-1}
     >
-      <div className={styles['heading-container']} id="popover-heading">
-        <h1 className={styles.heading}>{props.title}</h1>
-        <IconButton
-          active={true}
-          className={styles['close-button']}
-          icon={iconClear}
-          label="Close popover"
-          onPress={() => { setOpen(false); }}
-          ref={closeIconRef}
-        />
-      </div>
+      {
+        props.hideHeading ? undefined : (
+          <div className={styles['heading-container']} id="popover-heading">
+            <h1 className={styles.heading}>{props.title}</h1>
+            <IconButton
+              active={true}
+              className={styles['close-button']}
+              icon={iconClear}
+              label="Close popover"
+              onPress={() => { setOpen(false); }}
+              ref={closeIconRef}
+            />
+          </div>
+        )
+      }
       {props.children}
     </section>
   );
@@ -79,20 +83,25 @@ const Popover = forwardRef(function Popover(props, ref) {
 
 Popover.propTypes = {
   autoflush: PropTypes.bool,
+  className: PropTypes.string,
   children: PropTypes.node,
   flush: PropTypes.oneOf(['left', 'right']),
   onClose: PropTypes.func,
+  hideHeading: PropTypes.bool,
   /** Handles either a FocusEvent or MouseEvent. This is an additional predicate for configuring the closing behavior. */
   shouldClose: PropTypes.func,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
 };
 
 Popover.defaultProps = {
   autoflush: false,
+  className: undefined,
   children: undefined,
+  hideHeading: false,
   flush: 'left',
   shouldClose: () => true,
   onClose: () => {},
+  title: undefined,
 };
 
 export default Popover;

--- a/src/components/popover/popover.jsx
+++ b/src/components/popover/popover.jsx
@@ -54,7 +54,8 @@ const Popover = forwardRef(function Popover(props, ref) {
   return (
     <section
       aria-labelledby={props.hideHeading ? undefined : 'popover-heading'}
-      className={props.className || styles.container}
+      aria-label={props.ariaLabel}
+      className={props.className}
       onBlur={onBlur}
       ref={sectionRef}
       role="dialog"
@@ -83,6 +84,7 @@ const Popover = forwardRef(function Popover(props, ref) {
 
 Popover.propTypes = {
   autoflush: PropTypes.bool,
+  ariaLabel: PropTypes.string,
   className: PropTypes.string,
   children: PropTypes.node,
   flush: PropTypes.oneOf(['left', 'right']),
@@ -95,7 +97,9 @@ Popover.propTypes = {
 
 Popover.defaultProps = {
   autoflush: false,
-  className: undefined,
+  /** Use ariaLabel especially when setting hideHeading, this way a screen reader can detect the purpose of the popover */
+  ariaLabel: undefined,
+  className: styles.container,
   children: undefined,
   hideHeading: false,
   flush: 'left',

--- a/src/components/popover/popover.md
+++ b/src/components/popover/popover.md
@@ -61,3 +61,34 @@ function onPopoverOpenButtonClick() {
   )}
 </RefExample>
 ```
+
+Example with no heading that looks more like 'fly-out menu'
+```js
+import Popover from '@mavenlink/design-system/src/components/popover/popover.jsx';
+
+const popoverRef = React.createRef();
+const containerRef = React.createRef();
+
+function onBlur(event) {
+  if (shouldClose(event)) popoverRef.current.open = false;
+}
+
+function onButtonClicked(event) {
+  popoverRef.current.open = true;
+}
+
+function shouldClose(event) {
+  return !containerRef.current.contains(event.relatedTarget);
+}
+
+<div onBlur={onBlur} ref={containerRef} tabIndex={-1} style={{position: 'relative'}}>
+  <button onClick={onButtonClicked}>Fly Out menu example</button>
+  <Popover ref={popoverRef} shouldClose={shouldClose} hideHeading style={{position: 'absolute'}}>
+  <ul>
+    <li>option 1</li>
+    <li>option 2</li>
+    <li>option 3</li>
+  </ul>
+  </Popover>
+</div>
+```

--- a/src/components/popover/popover.test.jsx
+++ b/src/components/popover/popover.test.jsx
@@ -44,6 +44,19 @@ describe('Popover', () => {
     expect(screen.getByRole('dialog', { name: 'Another title' })).toBeInTheDocument();
   });
 
+  it('has a className api', () => {
+    render(<PopoverWithToggle title="Testing" className="unique-stuff" />);
+    userEvent.click(screen.getByText('Open Popover'));
+    expect(screen.getByRole('dialog')).toHaveClass('unique-stuff');
+  });
+
+  it('hides the title and close button when hideHeading is true', () => {
+    render(<PopoverWithToggle title="Testing" hideHeading />);
+    userEvent.click(screen.getByText('Open Popover'));
+    expect(screen.queryByText('Testing')).not.toBeInTheDocument();
+    expect(screen.queryByText('Close popover')).not.toBeInTheDocument();
+  });
+
   it('renders children', () => {
     render(<PopoverWithToggle title="Another title"><span>More text</span></PopoverWithToggle>);
 

--- a/src/components/popover/popover.test.jsx
+++ b/src/components/popover/popover.test.jsx
@@ -50,6 +50,12 @@ describe('Popover', () => {
     expect(screen.getByRole('dialog')).toHaveClass('unique-stuff');
   });
 
+  it('has a aria-label when ariaLabel prop is set', () => {
+    render(<PopoverWithToggle title="Testing" ariaLabel="This popover is for things" hideHeading />);
+    userEvent.click(screen.getByText('Open Popover'));
+    expect(screen.getByLabelText('This popover is for things')).toBeInTheDocument();
+  });
+
   it('hides the title and close button when hideHeading is true', () => {
     render(<PopoverWithToggle title="Testing" hideHeading />);
     userEvent.click(screen.getByText('Open Popover'));


### PR DESCRIPTION
feat(Popover): implement hideHeading api

<!--
In order to reduce overhead in maintaining PRs, please follow these rules:
1. If there is a pivotal story, replace the motivation+AC sections and add the pivotal story URL
2. If there is no pivotal story, fill in the motivation and AC sections
3. Complete the PR checklist
-->


## Motivation
We want a fly over menu, which is really just a popover but with no X to close, no padding and no title. I felt it was better to compose existing components than create flyover menu, which is really just pop-over in combination with list options.

## Acceptance Criteria


## PR upkeep checklist

- [ ] Change log entry
- [ ] Label(s)
- [ ] Assignee(s)
- [ ] Deployment URL: https://mavenlink.github.io/design-system/$BRANCH/
- [ ] (When ready for review) Reviewer(s)
- [ ] Green Bigmaven CI check
- [ ] DevQA on Bigmaven staging (e.g. does the work need to be imported in the internal design system?)
